### PR TITLE
update Newtonsoft.Json library, and use ILRepack on release builds to package JSON.net into the dll

### DIFF
--- a/src/VaultSharp/VaultSharp.csproj
+++ b/src/VaultSharp/VaultSharp.csproj
@@ -36,8 +36,8 @@
     <DocumentationFile>bin\Release\VaultSharp.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -161,13 +161,36 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>
-  <Target Name="AfterBuild">
-  </Target>
   -->
+  <Target Name="AfterBuild" Condition="'$(Configuration)' == 'Release'">
+    <ItemGroup>
+      <InputAssemblies Include="$(ProjectDir)$(OutputPath)$(AssemblyName).dll" />
+      <InputAssemblies Include="$(ProjectDir)$(OutputPath)Newtonsoft.Json.dll" />
+      <FilesToDelete Include="@(InputAssemblies)" />
+      <FilesToDelete Include="$(ProjectDir)$(OutputPath)Consul.pdb" />
+      <FilesToDelete Include="$(ProjectDir)$(OutputPath)Newtonsoft.Json.xml" />
+    </ItemGroup>
+    <PropertyGroup>
+      <OutputFileName>$(AssemblyName).dll</OutputFileName>
+      <OutputFolder>$(ProjectDir)$(OutputPath)Standalone</OutputFolder>
+      <FullOutputAssemblyPath>$(OutputFolder)\$(OutputFileName)</FullOutputAssemblyPath>
+      <MergerEXEPath>$(ProjectDir)..\..\packages\ILRepack.2.0.10\tools\ILRepack.exe</MergerEXEPath>
+      <MergerEXE Condition="('$(OS)' == 'Windows_NT')">$(MergerEXEPath)</MergerEXE>
+      <MergerEXE Condition="('$(OS)' != 'Windows_NT')">mono $(MergerEXEPath)</MergerEXE>
+      <MergerCommands>/parallel /internalize /out:$(FullOutputAssemblyPath) @(InputAssemblies->'%(FullPath)', ' ')</MergerCommands>
+    </PropertyGroup>
+    <Message Text="MERGING: @(InputAssemblies->'%(Filename)') into $(FullOutputAssemblyPath) with the command $(MergerEXE) $(MergerCommands)" Importance="High" />
+    <Exec Command="$(MergerEXE) $(MergerCommands)" WorkingDirectory="$(OutputPath)" />
+    <Message Text="DELETING: original files - @(FilesToDelete->'%(Filename)')" Importance="High" />
+    <Delete Files="@(FilesToDelete)" />
+    <Message Text="COPYING: @(FilesToCopy->'%(Filename)')" Importance="High" />
+    <Exec Condition="('$(OS)' == 'Windows_NT')" Command="xcopy /s /y $(OutputFolder)\*.* $(ProjectDir)$(OutputPath)" />
+    <Exec Condition="('$(OS)' != 'Windows_NT')" Command="cp -a $(OutputFolder)/. $(ProjectDir)$(OutputPath)/" />
+    <RemoveDir Directories="$(OutputFolder)" />
+  </Target>
 </Project>

--- a/src/VaultSharp/VaultSharp.csproj
+++ b/src/VaultSharp/VaultSharp.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props" Condition="Exists('..\..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -15,6 +16,8 @@
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>
     <SccProvider>SAK</SccProvider>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -34,6 +37,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\VaultSharp.XML</DocumentationFile>
+    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
@@ -192,5 +196,11 @@
     <Exec Condition="('$(OS)' == 'Windows_NT')" Command="xcopy /s /y $(OutputFolder)\*.* $(ProjectDir)$(OutputPath)" />
     <Exec Condition="('$(OS)' != 'Windows_NT')" Command="cp -a $(OutputFolder)/. $(ProjectDir)$(OutputPath)/" />
     <RemoveDir Directories="$(OutputFolder)" />
+  </Target>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props'))" />
   </Target>
 </Project>

--- a/src/VaultSharp/packages.config
+++ b/src/VaultSharp/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="ILRepack" version="2.0.10" targetFramework="net45" />
+  <package id="Microsoft.Net.Compilers" version="1.3.2" targetFramework="net45" developmentDependency="true" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
 </packages>

--- a/src/VaultSharp/packages.config
+++ b/src/VaultSharp/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
+  <package id="ILRepack" version="2.0.10" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
In order to reduce the clashing of JSON.net dependencies, this PR adds build steps that, on a release build, will take Newtonsoft.json.dll and package it into the VaultSharp.dll. When others import the VaultSharp.dll file, they can use whatever version of JSON.net they want and it will not clash with the version used by VaultSharp.dll.

This commit essentially duplicates the change in the .Net library for Consul (https://github.com/PlayFab/consuldotnet/pull/52). This is to solve the same issue that exists with that library: https://github.com/PlayFab/consuldotnet/issues/28