### PR TITLE
End2end test refactor

### DIFF
--- a/test/VaultSharp.UnitTests/Configs/end2end.hcl
+++ b/test/VaultSharp.UnitTests/Configs/end2end.hcl
@@ -1,0 +1,8 @@
+backend "file" {
+  path = "file_backend"
+}
+
+listener "tcp" {
+  address     = "127.0.0.1:8200"
+  tls_disable = 1
+}

--- a/test/VaultSharp.UnitTests/End2End/VaultClientEnd2EndTests.cs
+++ b/test/VaultSharp.UnitTests/End2End/VaultClientEnd2EndTests.cs
@@ -25,6 +25,7 @@ namespace VaultSharp.UnitTests.End2End
     {
         private const string MasterKey = "86332b94ffc41576c967d177f069ab52540f165b2821d1dbf4267a4b43b1370e";
         private const string RootToken = "a3d54c99-75fc-5bf3-e1e9-b6cb5b775e92";
+        private const string VaultUriWithPort = "http://127.0.0.1:8200";
 
         private Uri _vaultUri;
         private static MasterCredentials _masterCredentials;
@@ -43,9 +44,8 @@ namespace VaultSharp.UnitTests.End2End
         /// http://mrshipley.com/2018/01/10/implementing-a-teardown-method-in-xunit/
         /// </remarks>
         public VaultClientEnd2EndTests()
-        {
-            var vaultUriWithPort = "http://127.0.0.1:8200";
-            _vaultUri = new Uri(vaultUriWithPort);
+        { 
+            _vaultUri = new Uri(VaultUriWithPort);
             _unauthenticatedVaultClient = VaultClientFactory.CreateVaultClient(_vaultUri, null);
             _vaultServerProcess = StartVaultServerProcess();
             _masterCredentials = InitializeVault();

--- a/test/VaultSharp.UnitTests/End2End/VaultClientEnd2EndTests.cs
+++ b/test/VaultSharp.UnitTests/End2End/VaultClientEnd2EndTests.cs
@@ -31,7 +31,7 @@ namespace VaultSharp.UnitTests.End2End
 
         private static IVaultClient _authenticatedVaultClient;
         private static IVaultClient _unauthenticatedVaultClient;
-        private static int _vaultServerProcessId;
+        private static Process _vaultServerProcess;
 
         /// <summary>
         ///  Parameterless setup method that will run before each test
@@ -189,13 +189,8 @@ namespace VaultSharp.UnitTests.End2End
 
         public void Dispose()
         {
-            var process = Process.GetProcesses().FirstOrDefault(p => p.Id == _vaultServerProcessId);
-
-            if (process != null)
-            {
-                process.CloseMainWindow();
-                process.WaitForExit();
-            }
+            _vaultServerProcess.CloseMainWindow();
+            _vaultServerProcess.WaitForExit();
         }
 
         private static void InitializeVault()
@@ -240,11 +235,11 @@ namespace VaultSharp.UnitTests.End2End
             }
 
             // Start vault server process
-            Process process = StartVaultServerProcess();
+            _vaultServerProcess = StartVaultServerProcess();
 
-            Assert.NotNull(process);
+            Assert.NotNull(_vaultServerProcess);
 
-            _vaultServerProcessId = process.Id;
+            //_vaultServerProcess = process;
 
             var initialized = _unauthenticatedVaultClient.GetInitializationStatusAsync().Result;
             Assert.False(initialized);
@@ -279,13 +274,11 @@ namespace VaultSharp.UnitTests.End2End
 
             Assert.True(_masterCredentials.MasterKeys.Length == 7);
 
-            process.CloseMainWindow();
-            process.WaitForExit();
+            _vaultServerProcess.CloseMainWindow();
+            _vaultServerProcess.WaitForExit();
 
-            process = StartVaultServerProcess();
-            Assert.NotNull(process);
-
-            _vaultServerProcessId = process.Id;
+            _vaultServerProcess = StartVaultServerProcess();
+            Assert.NotNull(_vaultServerProcess);
 
             // todo find valid PGP keys
             //var pgpKeys = new[] { Convert.ToBase64String(Encoding.UTF8.GetBytes("pgp_key1")), Convert.ToBase64String(Encoding.UTF8.GetBytes("pgp_key2")) };

--- a/test/VaultSharp.UnitTests/VaultSharp.UnitTests.csproj
+++ b/test/VaultSharp.UnitTests/VaultSharp.UnitTests.csproj
@@ -88,6 +88,9 @@
     <None Include="acceptance-tests-vault-config.hcl">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="Configs\end2end.hcl">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
@@ -99,6 +102,7 @@
       <Name>VaultSharp</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>


### PR DESCRIPTION
I took a stab at refactoring the end to end tests with the goal of only having to have the vault.exe in the bin/Debug folder of the testing solution as the sole manual step in the testing process. The configuration is now in code. I'm hoping this is a reasonable configuration setup that contributors could agree upon when running the end to end tests. 

 The `VaultClientEnd2EndTests` class now inherits from IDisposable and each test starts a new vault.exe process. The initialization and unsealing of the vault server is now a series of methods called in the constructor. Each of the methods that performs a test is now an inidividual `[Fact]`.

