### PR TITLE
Debug vault client

### DIFF
--- a/test/VaultSharp.UnitTests/Configs/end2end.hcl
+++ b/test/VaultSharp.UnitTests/Configs/end2end.hcl
@@ -1,0 +1,8 @@
+backend "file" {
+  path = "file_backend"
+}
+
+listener "tcp" {
+  address     = "127.0.0.1:8200"
+  tls_disable = 1
+}

--- a/test/VaultSharp.UnitTests/End2End/DebugTestRunner.cs
+++ b/test/VaultSharp.UnitTests/End2End/DebugTestRunner.cs
@@ -1,0 +1,164 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using VaultSharp.Backends.Authentication.Models;
+using VaultSharp.Backends.Authentication.Models.Token;
+using VaultSharp.Backends.System.Models;
+using Xunit;
+
+namespace VaultSharp.UnitTests.End2End
+{
+    /// <summary>
+    /// This class expects the currently supported version of vault.exe file 
+    /// in the bin/Debug folder of the Testing solution.
+    /// The config is Configs\end2end.hcl
+    /// </summary>
+    public class DebugVaultServer : IDisposable
+    {
+        public MasterCredentials MasterCredentials { get; private set; }
+        public IVaultClient AuthenticatedVaultClient { get; private set; }
+        public IVaultClient UnauthenticatedVaultClient { get; private set; }
+        private Process _vaultServerProcess;
+        private string _workingDirectory;
+
+        public DebugVaultServer(Uri vaultUri = null, bool unseal = true)
+        {
+            if (vaultUri == null)
+            {
+                vaultUri = new Uri("http://127.0.0.1:8200");
+            }
+
+            CheckForVaultInstallation(Directory.GetCurrentDirectory());
+
+            _workingDirectory = CreateLocalFileBackend();
+            _vaultServerProcess = StartVaultServerProcess();
+
+            UnauthenticatedVaultClient = VaultClientFactory.CreateVaultClient(vaultUri, null);
+            MasterCredentials = InitializeVault();
+
+            if (unseal) Unseal(vaultUri);
+        }
+
+        // Create fresh file_directory in the testing folder
+        private string CreateLocalFileBackend()
+        {
+            var workingDirectory = Path.Combine(Directory.GetCurrentDirectory(), "file_backend");
+            if (Directory.Exists(workingDirectory))
+                Directory.Delete(workingDirectory, true);
+
+            Directory.CreateDirectory(workingDirectory);
+
+            return workingDirectory;
+        }
+
+        private void CheckForVaultInstallation(string folderPathToVaultExecutable)
+        {
+            var path = Path.Combine(folderPathToVaultExecutable, "vault.exe");
+            if (!File.Exists(path))
+            {
+                throw new FileNotFoundException($"Could not find the Vault executable. Excepted path: {path}");
+            }
+        }
+
+        /// <summary>
+        /// Run the vault.exe that is expected to be in the bin/Debug folder of this project
+        /// </summary>
+        /// <returns>
+        /// <see cref="System.Diagnostics.Process"/> running the vault.exe
+        /// </returns>
+        private Process StartVaultServerProcess()
+        {
+            // Todo: Create Load Config helper methods
+            var configPath = Path.Combine(Directory.GetCurrentDirectory(), "Configs", "end2end.hcl");
+            var startupArguements = $"server -log-level debug -config={configPath}";
+
+            var processStartInfo = new ProcessStartInfo("vault.exe");
+            processStartInfo.WorkingDirectory = _workingDirectory;
+            processStartInfo.Arguments = startupArguements;
+            processStartInfo.RedirectStandardError = true;
+            processStartInfo.RedirectStandardOutput = true;
+            processStartInfo.UseShellExecute = false;
+
+            var process = new Process();
+            process.StartInfo = processStartInfo;
+            process.Start();
+
+            Thread.Sleep(100);
+            if (process.HasExited)
+            {
+                var err = process.StandardError.ReadToEnd();
+                var output = process.StandardOutput.ReadToEnd();
+                throw new Exception("The vault server executable used in these tests had trouble starting. \n" +
+                    $"STDOUT: \"{output}\"\n" +
+                    $"STDERR: \"{err}\"\n" +
+                    "The End2End tests expect a vault executable in the bin/Debug folder."
+                    );
+            }
+
+            return process;
+        }
+
+        /// <summary>
+        /// Initialize the vault server. Basic health checks
+        /// </summary>
+        /// <returns><see cref="Backends.System.Models.MasterCredentials"/> of the Vault instance sealed and initialized</returns>
+        private MasterCredentials InitializeVault()
+        {
+            var initialized = UnauthenticatedVaultClient.GetInitializationStatusAsync().Result;
+            Assert.False(initialized);
+
+            var healthStatus = UnauthenticatedVaultClient.GetHealthStatusAsync().Result;
+            Assert.False(healthStatus.Initialized);
+
+            // Initialize Vault
+            var masterCredentials = UnauthenticatedVaultClient.InitializeAsync(new InitializeOptions
+            {
+                SecretShares = 5,
+                SecretThreshold = 3
+            }).Result;
+
+            healthStatus = UnauthenticatedVaultClient.GetHealthStatusAsync().Result;
+            Assert.True(healthStatus.Initialized);
+            Assert.True(healthStatus.Sealed);
+
+            return masterCredentials;
+        }
+
+        /// <summary>
+        /// Unseal the vault instance
+        /// </summary>
+        private void Unseal(Uri vaultUri)
+        {
+            foreach (var masterKey in MasterCredentials.MasterKeys)
+            {
+                var sealStatus = UnauthenticatedVaultClient.UnsealAsync(masterKey).Result;
+
+                if (!sealStatus.Sealed)
+                {
+                    var healthStatus = UnauthenticatedVaultClient.GetHealthStatusAsync().Result;
+                    Assert.True(healthStatus.Initialized);
+                    Assert.False(healthStatus.Sealed);
+
+                    // we are acting as the root user here.
+
+                    IAuthenticationInfo tokenAuthenticationInfo =
+                        new TokenAuthenticationInfo(MasterCredentials.RootToken);
+                    AuthenticatedVaultClient = VaultClientFactory.CreateVaultClient(vaultUri, tokenAuthenticationInfo);
+
+                    break;
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            _vaultServerProcess.CloseMainWindow();
+            // Todo: Figure out why WaitToExit() here doesn't work.
+            // If WaitToExit() was used, the process was not shut down correctly
+            // It had a lock on the config directory and the next Test could not run
+            //_vaultServerProcess.WaitForExit(100);
+            _vaultServerProcess.Kill();
+        }
+    }
+}

--- a/test/VaultSharp.UnitTests/End2End/DebugVaultClient.cs
+++ b/test/VaultSharp.UnitTests/End2End/DebugVaultClient.cs
@@ -14,7 +14,7 @@ namespace VaultSharp.UnitTests.End2End
     /// in the bin/Debug folder of the Testing solution.
     /// The config is Configs\end2end.hcl
     /// </summary>
-    public class DebugVaultServer : IDisposable
+    public class DebugVaultClient : IDisposable
     {
         public MasterCredentials MasterCredentials { get; private set; }
         public IVaultClient AuthenticatedVaultClient { get; private set; }
@@ -22,7 +22,7 @@ namespace VaultSharp.UnitTests.End2End
         private Process _vaultServerProcess;
         private string _workingDirectory;
 
-        public DebugVaultServer(Uri vaultUri = null, bool unseal = true)
+        public DebugVaultClient(Uri vaultUri = null, bool unseal = true)
         {
             if (vaultUri == null)
             {
@@ -32,6 +32,7 @@ namespace VaultSharp.UnitTests.End2End
             CheckForVaultInstallation(Directory.GetCurrentDirectory());
 
             _workingDirectory = CreateLocalFileBackend();
+
             _vaultServerProcess = StartVaultServerProcess();
 
             UnauthenticatedVaultClient = VaultClientFactory.CreateVaultClient(vaultUri, null);

--- a/test/VaultSharp.UnitTests/End2End/DebugVaultClient.cs
+++ b/test/VaultSharp.UnitTests/End2End/DebugVaultClient.cs
@@ -10,6 +10,7 @@ using Xunit;
 namespace VaultSharp.UnitTests.End2End
 {
     /// <summary>
+    /// Handles runnning the Vault server and exposes a master client and an unauthenticated client
     /// This class expects the currently supported version of vault.exe file 
     /// in the bin/Debug folder of the Testing solution.
     /// The config is Configs\end2end.hcl
@@ -22,6 +23,11 @@ namespace VaultSharp.UnitTests.End2End
         private Process _vaultServerProcess;
         private string _workingDirectory;
 
+        /// <summary>
+        /// Constructor with sane defaults
+        /// </summary>
+        /// <param name="vaultUri">URI override for where the vault server expects to be listening</param>
+        /// <param name="unseal">Whether or not to autounseal the Vault server</param>
         public DebugVaultClient(Uri vaultUri = null, bool unseal = true)
         {
             if (vaultUri == null)
@@ -41,7 +47,25 @@ namespace VaultSharp.UnitTests.End2End
             if (unseal) Unseal(vaultUri);
         }
 
-        // Create fresh file_directory in the testing folder
+
+        /// <summary>
+        /// Expects vault.exe in the folder passed to this method
+        /// Currently this is hardcoded to the bin/Debug folder
+        /// </summary>
+        /// <param name="folderPathToVaultExecutable">Path the to vault executable</param>
+        private void CheckForVaultInstallation(string folderPathToVaultExecutable)
+        {
+            var path = Path.Combine(folderPathToVaultExecutable, "vault.exe");
+            if (!File.Exists(path))
+            {
+                throw new FileNotFoundException($"Could not find the Vault executable. Excepted path: {path}");
+            }
+        }
+
+        /// <summary>
+        /// Create fresh file_directory in the testing folder
+        /// </summary>
+        /// <returns></returns>
         private string CreateLocalFileBackend()
         {
             var workingDirectory = Path.Combine(Directory.GetCurrentDirectory(), "file_backend");
@@ -53,20 +77,11 @@ namespace VaultSharp.UnitTests.End2End
             return workingDirectory;
         }
 
-        private void CheckForVaultInstallation(string folderPathToVaultExecutable)
-        {
-            var path = Path.Combine(folderPathToVaultExecutable, "vault.exe");
-            if (!File.Exists(path))
-            {
-                throw new FileNotFoundException($"Could not find the Vault executable. Excepted path: {path}");
-            }
-        }
-
         /// <summary>
         /// Run the vault.exe that is expected to be in the bin/Debug folder of this project
         /// </summary>
         /// <returns>
-        /// <see cref="System.Diagnostics.Process"/> running the vault.exe
+        /// <see cref="Process"/> running the vault.exe
         /// </returns>
         private Process StartVaultServerProcess()
         {

--- a/test/VaultSharp.UnitTests/End2End/VaultClientEnd2EndTests.cs
+++ b/test/VaultSharp.UnitTests/End2End/VaultClientEnd2EndTests.cs
@@ -25,6 +25,7 @@ namespace VaultSharp.UnitTests.End2End
     {
         private const string MasterKey = "86332b94ffc41576c967d177f069ab52540f165b2821d1dbf4267a4b43b1370e";
         private const string RootToken = "a3d54c99-75fc-5bf3-e1e9-b6cb5b775e92";
+        private const string VaultUriWithPort = "http://127.0.0.1:8200";
 
         private Uri _vaultUri;
         private static MasterCredentials _masterCredentials;
@@ -43,9 +44,8 @@ namespace VaultSharp.UnitTests.End2End
         /// http://mrshipley.com/2018/01/10/implementing-a-teardown-method-in-xunit/
         /// </remarks>
         public VaultClientEnd2EndTests()
-        {
-            var vaultUriWithPort = "http://127.0.0.1:8200";
-            _vaultUri = new Uri(vaultUriWithPort);
+        { 
+            _vaultUri = new Uri(VaultUriWithPort);
             _unauthenticatedVaultClient = VaultClientFactory.CreateVaultClient(_vaultUri, null);
             _vaultServerProcess = StartVaultServerProcess();
             _masterCredentials = InitializeVault();

--- a/test/VaultSharp.UnitTests/End2End/VaultClientEnd2EndTests.cs
+++ b/test/VaultSharp.UnitTests/End2End/VaultClientEnd2EndTests.cs
@@ -31,7 +31,7 @@ namespace VaultSharp.UnitTests.End2End
 
         private static IVaultClient _authenticatedVaultClient;
         private static IVaultClient _unauthenticatedVaultClient;
-        private static int _vaultServerProcessId;
+        private static Process _vaultServerProcess;
 
         /// <summary>
         ///  Parameterless setup method that will run before each test
@@ -189,13 +189,8 @@ namespace VaultSharp.UnitTests.End2End
 
         public void Dispose()
         {
-            var process = Process.GetProcesses().FirstOrDefault(p => p.Id == _vaultServerProcessId);
-
-            if (process != null)
-            {
-                process.CloseMainWindow();
-                process.WaitForExit();
-            }
+            _vaultServerProcess.CloseMainWindow();
+            _vaultServerProcess.WaitForExit();
         }
 
         private static void InitializeVault()
@@ -240,11 +235,11 @@ namespace VaultSharp.UnitTests.End2End
             }
 
             // Start vault server process
-            Process process = StartVaultServerProcess();
+            _vaultServerProcess = StartVaultServerProcess();
 
-            Assert.NotNull(process);
+            Assert.NotNull(_vaultServerProcess);
 
-            _vaultServerProcessId = process.Id;
+            //_vaultServerProcess = process;
 
             var initialized = _unauthenticatedVaultClient.GetInitializationStatusAsync().Result;
             Assert.False(initialized);
@@ -279,13 +274,11 @@ namespace VaultSharp.UnitTests.End2End
 
             Assert.True(_masterCredentials.MasterKeys.Length == 7);
 
-            process.CloseMainWindow();
-            process.WaitForExit();
+            _vaultServerProcess.CloseMainWindow();
+            _vaultServerProcess.WaitForExit();
 
-            process = StartVaultServerProcess();
-            Assert.NotNull(process);
-
-            _vaultServerProcessId = process.Id;
+            _vaultServerProcess = StartVaultServerProcess();
+            Assert.NotNull(_vaultServerProcess);
 
             // todo find valid PGP keys
             //var pgpKeys = new[] { Convert.ToBase64String(Encoding.UTF8.GetBytes("pgp_key1")), Convert.ToBase64String(Encoding.UTF8.GetBytes("pgp_key2")) };

--- a/test/VaultSharp.UnitTests/VaultSharp.UnitTests.csproj
+++ b/test/VaultSharp.UnitTests/VaultSharp.UnitTests.csproj
@@ -88,6 +88,9 @@
     <None Include="acceptance-tests-vault-config.hcl">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="Configs\end2end.hcl">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
@@ -99,6 +102,7 @@
       <Name>VaultSharp</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/test/VaultSharp.UnitTests/VaultSharp.UnitTests.csproj
+++ b/test/VaultSharp.UnitTests/VaultSharp.UnitTests.csproj
@@ -79,7 +79,7 @@
   <ItemGroup>
     <Compile Include="DataAccess\HttpDataAccessManagerTests.cs" />
     <Compile Include="AcceptanceTests.cs" />
-    <Compile Include="End2End\DebugTestRunner.cs" />
+    <Compile Include="End2End\DebugVaultClient.cs" />
     <Compile Include="Infrastructure\Validation\CheckerTests.cs" />
     <Compile Include="VaultClientFactoryTests.cs" />
     <Compile Include="End2End\VaultClientEnd2EndTests.cs" />

--- a/test/VaultSharp.UnitTests/VaultSharp.UnitTests.csproj
+++ b/test/VaultSharp.UnitTests/VaultSharp.UnitTests.csproj
@@ -79,6 +79,7 @@
   <ItemGroup>
     <Compile Include="DataAccess\HttpDataAccessManagerTests.cs" />
     <Compile Include="AcceptanceTests.cs" />
+    <Compile Include="End2End\DebugTestRunner.cs" />
     <Compile Include="Infrastructure\Validation\CheckerTests.cs" />
     <Compile Include="VaultClientFactoryTests.cs" />
     <Compile Include="End2End\VaultClientEnd2EndTests.cs" />


### PR DESCRIPTION
Building off of MR #45 - I abstracted all the Vault server setup and created the `DebugVaultClient` that initializes a new instance of the vault server for testing. It exposes two `MasterCredentials`, an `AuthenticatedVaultClient` and an `UnauthenticatedVaultClient` as public properties with Private setters. It currently expects the `vault.exe` file in the bin/Debug folder of the testing project, this could be overridden. The vault uri and whether or not to unseal the vault server can be passed in as parameters and are set with (hopefully) sane defaults. 

The `VaultClientEnd2EndTests` class has been refactored to use the `DebugVaultClient`

I'm not sure about the name `DebugVaultClient` I did this in an effort to separate the concerns of the tests and running/managing the vault server.  I'm hoping to create more End2End integration tests using this abstraction.