### PR TITLE
Fix default mount for V1 kv engine

### DIFF
--- a/src/VaultSharp/V1/SecretsEngines/KeyValue/V1/IKeyValueSecretsEngineV1.cs
+++ b/src/VaultSharp/V1/SecretsEngines/KeyValue/V1/IKeyValueSecretsEngineV1.cs
@@ -15,7 +15,7 @@ namespace VaultSharp.V1.SecretsEngines.KeyValue.V1
         /// <param name="path"><para>[required]</para>
         /// The location path where the secret needs to be read from.</param>
         /// <param name="mountPoint"><para>[optional]</para>
-        /// The mount point for the KeyValue backend. Defaults to <see cref="SecretsEngineDefaultPaths.KeyValue" />
+        /// The mount point for the KeyValue backend. Defaults to <see cref="SecretsEngineDefaultPaths.KeyValueV1" />
         /// Provide a value only if you have customized the mount point.</param>
         /// <param name="wrapTimeToLive">
         /// <para>[required]</para>
@@ -24,7 +24,7 @@ namespace VaultSharp.V1.SecretsEngines.KeyValue.V1
         /// <returns>
         /// The secret with the data.
         /// </returns>
-        Task<Secret<Dictionary<string, object>>> ReadSecretAsync(string path, string mountPoint = SecretsEngineDefaultPaths.KeyValue, string wrapTimeToLive = null);
+        Task<Secret<Dictionary<string, object>>> ReadSecretAsync(string path, string mountPoint = SecretsEngineDefaultPaths.KeyValueV1, string wrapTimeToLive = null);
 
         /// <summary>
         /// Retrieves the secret location path entries at the specified location.
@@ -34,7 +34,7 @@ namespace VaultSharp.V1.SecretsEngines.KeyValue.V1
         /// <param name="path"><para>[required]</para>
         /// The location path where the secret needs to be read from.</param>
         /// <param name="mountPoint"><para>[optional]</para>
-        /// The mount point for the Generic backend. Defaults to <see cref="SecretsEngineDefaultPaths.KeyValue" />
+        /// The mount point for the Generic backend. Defaults to <see cref="SecretsEngineDefaultPaths.KeyValueV1" />
         /// Provide a value only if you have customized the mount point.</param>
         /// <param name="wrapTimeToLive">
         /// <para>[required]</para>
@@ -43,7 +43,7 @@ namespace VaultSharp.V1.SecretsEngines.KeyValue.V1
         /// <returns>
         /// The secret list with the data.
         /// </returns>
-        Task<Secret<ListInfo>> ReadSecretPathsAsync(string path, string mountPoint = SecretsEngineDefaultPaths.KeyValue, string wrapTimeToLive = null);
+        Task<Secret<ListInfo>> ReadSecretPathsAsync(string path, string mountPoint = SecretsEngineDefaultPaths.KeyValueV1, string wrapTimeToLive = null);
 
         /// <summary>
         /// Stores a secret at the specified location. If the value does not yet exist, the calling token must have an ACL policy granting the create capability. 
@@ -54,7 +54,7 @@ namespace VaultSharp.V1.SecretsEngines.KeyValue.V1
         /// <param name="values"><para>[required]</para>
         /// The value to be written.</param>
         /// <param name="mountPoint"><para>[optional]</para>
-        /// The mount point for the Generic backend. Defaults to <see cref="SecretsEngineDefaultPaths.KeyValue" />
+        /// The mount point for the Generic backend. Defaults to <see cref="SecretsEngineDefaultPaths.KeyValueV1" />
         /// Provide a value only if you have customized the mount point.
         /// </param>
         /// <returns>
@@ -68,7 +68,7 @@ namespace VaultSharp.V1.SecretsEngines.KeyValue.V1
         /// Even with a ttl set, the secrets engine never removes data on its own.The ttl key is merely advisory.
         /// When reading a value with a ttl, both the ttl key and the refresh interval will reflect the value:
         /// </remarks>
-        Task WriteSecretAsync(string path, IDictionary<string, object> values, string mountPoint = SecretsEngineDefaultPaths.KeyValue);
+        Task WriteSecretAsync(string path, IDictionary<string, object> values, string mountPoint = SecretsEngineDefaultPaths.KeyValueV1);
 
         /// <summary>
         /// Deletes the value at the specified path in Vault.
@@ -76,12 +76,12 @@ namespace VaultSharp.V1.SecretsEngines.KeyValue.V1
         /// <param name="path"><para>[required]</para>
         /// The path where the value is to be stored.</param>
         /// <param name="mountPoint"><para>[optional]</para>
-        /// The mount point for the Generic backend. Defaults to <see cref="SecretsEngineDefaultPaths.KeyValue" />
+        /// The mount point for the Generic backend. Defaults to <see cref="SecretsEngineDefaultPaths.KeyValueV1" />
         /// Provide a value only if you have customized the mount point.
         /// </param>
         /// <returns>
         /// The task.
         /// </returns>
-        Task DeleteSecretAsync(string path, string mountPoint = SecretsEngineDefaultPaths.KeyValue);
+        Task DeleteSecretAsync(string path, string mountPoint = SecretsEngineDefaultPaths.KeyValueV1);
     }
 }

--- a/src/VaultSharp/V1/SecretsEngines/KeyValue/V1/KeyValueSecretsEngineV1Provider.cs
+++ b/src/VaultSharp/V1/SecretsEngines/KeyValue/V1/KeyValueSecretsEngineV1Provider.cs
@@ -15,7 +15,7 @@ namespace VaultSharp.V1.SecretsEngines.KeyValue.V1
             _polymath = polymath;
         }
 
-        public async Task<Secret<Dictionary<string, object>>> ReadSecretAsync(string path, string mountPoint = SecretsEngineDefaultPaths.KeyValue, string wrapTimeToLive = null)
+        public async Task<Secret<Dictionary<string, object>>> ReadSecretAsync(string path, string mountPoint = SecretsEngineDefaultPaths.KeyValueV1, string wrapTimeToLive = null)
         {
             Checker.NotNull(mountPoint, "mountPoint");
             Checker.NotNull(path, "path");
@@ -23,7 +23,7 @@ namespace VaultSharp.V1.SecretsEngines.KeyValue.V1
             return await _polymath.MakeVaultApiRequest<Secret<Dictionary<string, object>>>("v1/" + mountPoint.Trim('/') + "/" + path.Trim('/'), HttpMethod.Get, wrapTimeToLive: wrapTimeToLive).ConfigureAwait(_polymath.VaultClientSettings.ContinueAsyncTasksOnCapturedContext);
         }
 
-        public async Task<Secret<ListInfo>> ReadSecretPathsAsync(string path, string mountPoint = SecretsEngineDefaultPaths.KeyValue, string wrapTimeToLive = null)
+        public async Task<Secret<ListInfo>> ReadSecretPathsAsync(string path, string mountPoint = SecretsEngineDefaultPaths.KeyValueV1, string wrapTimeToLive = null)
         {
             Checker.NotNull(mountPoint, "mountPoint");
 
@@ -31,7 +31,7 @@ namespace VaultSharp.V1.SecretsEngines.KeyValue.V1
             return await _polymath.MakeVaultApiRequest<Secret<ListInfo>>("v1/" + mountPoint.Trim('/') + "/" + suffixPath + "?list=true", HttpMethod.Get, wrapTimeToLive: wrapTimeToLive).ConfigureAwait(_polymath.VaultClientSettings.ContinueAsyncTasksOnCapturedContext);
         }
 
-        public async Task WriteSecretAsync(string path, IDictionary<string, object> values, string mountPoint = SecretsEngineDefaultPaths.KeyValue)
+        public async Task WriteSecretAsync(string path, IDictionary<string, object> values, string mountPoint = SecretsEngineDefaultPaths.KeyValueV1)
         {
             Checker.NotNull(mountPoint, "mountPoint");
             Checker.NotNull(path, "path");
@@ -39,7 +39,7 @@ namespace VaultSharp.V1.SecretsEngines.KeyValue.V1
             await _polymath.MakeVaultApiRequest("v1/" + mountPoint.Trim('/') + "/" + path.Trim('/'), HttpMethod.Post, values).ConfigureAwait(_polymath.VaultClientSettings.ContinueAsyncTasksOnCapturedContext);
         }
 
-        public async Task DeleteSecretAsync(string path, string mountPoint = SecretsEngineDefaultPaths.KeyValue)
+        public async Task DeleteSecretAsync(string path, string mountPoint = SecretsEngineDefaultPaths.KeyValueV1)
         {
             Checker.NotNull(mountPoint, "mountPoint");
             Checker.NotNull(path, "path");

--- a/src/VaultSharp/V1/SecretsEngines/KeyValue/V2/IKeyValueSecretsEngineV2.cs
+++ b/src/VaultSharp/V1/SecretsEngines/KeyValue/V2/IKeyValueSecretsEngineV2.cs
@@ -14,7 +14,7 @@ namespace VaultSharp.V1.SecretsEngines.KeyValue.V2
         /// </summary>
         /// <param name="path"><para>[required]</para>
         /// The location path where the secret needs to be read from.</param>
-        /// The mount point for the KeyValue backend. Defaults to <see cref="SecretsEngineDefaultPaths.KeyValue" />
+        /// The mount point for the KeyValue backend. Defaults to <see cref="SecretsEngineDefaultPaths.KeyValueV2" />
         /// Provide a value only if you have customized the mount point.</param>
         /// <param name="version"><para>[optional]</para>
         /// Specifies the version to return. If not set the latest version is returned.
@@ -29,7 +29,7 @@ namespace VaultSharp.V1.SecretsEngines.KeyValue.V2
         /// <returns>
         /// The secret with the data.
         /// </returns>
-        Task<Secret<SecretData>> ReadSecretAsync(string path, int? version = null, string mountPoint = SecretsEngineDefaultPaths.KeyValue, string wrapTimeToLive = null);
+        Task<Secret<SecretData>> ReadSecretAsync(string path, int? version = null, string mountPoint = SecretsEngineDefaultPaths.KeyValueV2, string wrapTimeToLive = null);
 
         /// <summary>
         /// Retrieves the secret location path entries at the specified location.
@@ -39,7 +39,7 @@ namespace VaultSharp.V1.SecretsEngines.KeyValue.V2
         /// <param name="path"><para>[required]</para>
         /// The location path where the secret needs to be read from.</param>
         /// <param name="mountPoint"><para>[optional]</para>
-        /// The mount point for the Generic backend. Defaults to <see cref="SecretsEngineDefaultPaths.KeyValue" />
+        /// The mount point for the Generic backend. Defaults to <see cref="SecretsEngineDefaultPaths.KeyValueV2" />
         /// Provide a value only if you have customized the mount point.</param>
         /// <param name="wrapTimeToLive">
         /// <para>[required]</para>
@@ -48,14 +48,14 @@ namespace VaultSharp.V1.SecretsEngines.KeyValue.V2
         /// <returns>
         /// The secret list with the data.
         /// </returns>
-        Task<Secret<ListInfo>> ReadSecretPathsAsync(string path, string mountPoint = SecretsEngineDefaultPaths.KeyValue, string wrapTimeToLive = null);
+        Task<Secret<ListInfo>> ReadSecretPathsAsync(string path, string mountPoint = SecretsEngineDefaultPaths.KeyValueV2, string wrapTimeToLive = null);
 
         /// <summary>
         /// Retrieves the secret metadata at the specified location.
         /// </summary>
         /// <param name="path"><para>[required]</para>
         /// The location path where the secret needs to be read from.</param>
-        /// The mount point for the KeyValue backend. Defaults to <see cref="SecretsEngineDefaultPaths.KeyValue" />
+        /// The mount point for the KeyValue backend. Defaults to <see cref="SecretsEngineDefaultPaths.KeyValueV2" />
         /// Provide a value only if you have customized the mount point.</param>
         /// <param name="mountPoint"><para>[optional]</para>
         /// The mount point for the KeyValue backend. Defaults to <see cref="SecretsEngineDefaultPaths.KeyValue" />
@@ -67,7 +67,7 @@ namespace VaultSharp.V1.SecretsEngines.KeyValue.V2
         /// <returns>
         /// The secret metadata.
         /// </returns>
-        Task<Secret<FullSecretMetadata>> ReadSecretMetadataAsync(string path, string mountPoint = SecretsEngineDefaultPaths.KeyValue, string wrapTimeToLive = null);
+        Task<Secret<FullSecretMetadata>> ReadSecretMetadataAsync(string path, string mountPoint = SecretsEngineDefaultPaths.KeyValueV2, string wrapTimeToLive = null);
 
         /// <summary>
         /// Stores a secret at the specified location. If the value does not yet exist, the calling token must have an ACL policy granting the create capability. 
@@ -83,7 +83,7 @@ namespace VaultSharp.V1.SecretsEngines.KeyValue.V2
         /// If the index is non-zero the write will only be allowed if the key’s current version matches the version specified in the cas parameter.
         /// </param>
         /// <param name="mountPoint"><para>[optional]</para>
-        /// The mount point for the Generic backend. Defaults to <see cref="SecretsEngineDefaultPaths.KeyValue" />
+        /// The mount point for the Generic backend. Defaults to <see cref="SecretsEngineDefaultPaths.KeyValueV2" />
         /// Provide a value only if you have customized the mount point.
         /// </param>
         /// <returns>
@@ -97,7 +97,7 @@ namespace VaultSharp.V1.SecretsEngines.KeyValue.V2
         /// Even with a ttl set, the secrets engine never removes data on its own.The ttl key is merely advisory.
         /// When reading a value with a ttl, both the ttl key and the refresh interval will reflect the value:
         /// </remarks>
-        Task WriteSecretAsync(string path, IDictionary<string, object> data, int? checkAndSet = null, string mountPoint = SecretsEngineDefaultPaths.KeyValue);
+        Task WriteSecretAsync(string path, IDictionary<string, object> data, int? checkAndSet = null, string mountPoint = SecretsEngineDefaultPaths.KeyValueV2);
 
         /// <summary>
         /// Deletes the value at the specified path in Vault.
@@ -109,12 +109,12 @@ namespace VaultSharp.V1.SecretsEngines.KeyValue.V2
         /// The versions to destroy. Their data will be permanently deleted.
         /// </param>
         /// <param name="mountPoint"><para>[optional]</para>
-        /// The mount point for the Generic backend. Defaults to <see cref="SecretsEngineDefaultPaths.KeyValue" />
+        /// The mount point for the Generic backend. Defaults to <see cref="SecretsEngineDefaultPaths.KeyValueV2" />
         /// Provide a value only if you have customized the mount point.
         /// </param>
         /// <returns>
         /// The task.
         /// </returns>
-        Task DestroySecretAsync(string path, IList<int> versions, string mountPoint = SecretsEngineDefaultPaths.KeyValue);
+        Task DestroySecretAsync(string path, IList<int> versions, string mountPoint = SecretsEngineDefaultPaths.KeyValueV2);
     }
 }

--- a/src/VaultSharp/V1/SecretsEngines/KeyValue/V2/KeyValueSecretsEngineV2Provider.cs
+++ b/src/VaultSharp/V1/SecretsEngines/KeyValue/V2/KeyValueSecretsEngineV2Provider.cs
@@ -15,7 +15,7 @@ namespace VaultSharp.V1.SecretsEngines.KeyValue.V2
             _polymath = polymath;
         }
 
-        public async Task<Secret<SecretData>> ReadSecretAsync(string path, int? version = null, string mountPoint = SecretsEngineDefaultPaths.KeyValue, string wrapTimeToLive = null)
+        public async Task<Secret<SecretData>> ReadSecretAsync(string path, int? version = null, string mountPoint = SecretsEngineDefaultPaths.KeyValueV2, string wrapTimeToLive = null)
         {
             Checker.NotNull(mountPoint, "mountPoint");
             Checker.NotNull(path, "path");
@@ -23,7 +23,7 @@ namespace VaultSharp.V1.SecretsEngines.KeyValue.V2
             return await _polymath.MakeVaultApiRequest<Secret<SecretData>>("v1/" + mountPoint.Trim('/') + "/data/" + path.Trim('/') + (version != null ? ("?version=" + version) : ""), HttpMethod.Get, wrapTimeToLive: wrapTimeToLive).ConfigureAwait(_polymath.VaultClientSettings.ContinueAsyncTasksOnCapturedContext);
         }
 
-        public async Task<Secret<FullSecretMetadata>> ReadSecretMetadataAsync(string path, string mountPoint = SecretsEngineDefaultPaths.KeyValue, string wrapTimeToLive = null)
+        public async Task<Secret<FullSecretMetadata>> ReadSecretMetadataAsync(string path, string mountPoint = SecretsEngineDefaultPaths.KeyValueV2, string wrapTimeToLive = null)
         {
             Checker.NotNull(mountPoint, "mountPoint");
             Checker.NotNull(path, "path");
@@ -31,7 +31,7 @@ namespace VaultSharp.V1.SecretsEngines.KeyValue.V2
             return await _polymath.MakeVaultApiRequest<Secret<FullSecretMetadata>>("v1/" + mountPoint.Trim('/') + "/metadata/" + path.Trim('/'), HttpMethod.Get, wrapTimeToLive: wrapTimeToLive).ConfigureAwait(_polymath.VaultClientSettings.ContinueAsyncTasksOnCapturedContext);
         }
 
-        public async Task<Secret<ListInfo>> ReadSecretPathsAsync(string path, string mountPoint = SecretsEngineDefaultPaths.KeyValue, string wrapTimeToLive = null)
+        public async Task<Secret<ListInfo>> ReadSecretPathsAsync(string path, string mountPoint = SecretsEngineDefaultPaths.KeyValueV2, string wrapTimeToLive = null)
         {
             Checker.NotNull(mountPoint, "mountPoint");
 
@@ -39,7 +39,7 @@ namespace VaultSharp.V1.SecretsEngines.KeyValue.V2
             return await _polymath.MakeVaultApiRequest<Secret<ListInfo>>("v1/" + mountPoint.Trim('/') + "/metadata/" + suffixPath + "?list=true", HttpMethod.Get, wrapTimeToLive: wrapTimeToLive).ConfigureAwait(_polymath.VaultClientSettings.ContinueAsyncTasksOnCapturedContext);
         }
 
-        public async Task WriteSecretAsync(string path, IDictionary<string, object> data, int? checkAndSet = null, string mountPoint = SecretsEngineDefaultPaths.KeyValue)
+        public async Task WriteSecretAsync(string path, IDictionary<string, object> data, int? checkAndSet = null, string mountPoint = SecretsEngineDefaultPaths.KeyValueV2)
         {
             Checker.NotNull(mountPoint, "mountPoint");
             Checker.NotNull(path, "path");
@@ -57,7 +57,7 @@ namespace VaultSharp.V1.SecretsEngines.KeyValue.V2
             await _polymath.MakeVaultApiRequest("v1/" + mountPoint.Trim('/') + "/data/" + path.Trim('/'), HttpMethod.Post, requestData).ConfigureAwait(_polymath.VaultClientSettings.ContinueAsyncTasksOnCapturedContext);
         }
 
-        public async Task DestroySecretAsync(string path, IList<int> versions, string mountPoint = SecretsEngineDefaultPaths.KeyValue)
+        public async Task DestroySecretAsync(string path, IList<int> versions, string mountPoint = SecretsEngineDefaultPaths.KeyValueV2)
         {
             Checker.NotNull(mountPoint, "mountPoint");
             Checker.NotNull(path, "path");

--- a/src/VaultSharp/V1/SecretsEngines/SecretsEngineDefaultPaths.cs
+++ b/src/VaultSharp/V1/SecretsEngines/SecretsEngineDefaultPaths.cs
@@ -11,7 +11,8 @@
         public const string Cubbyhole = "cubbyhole";
         public const string Database = "database";
         public const string GoogleCloud = "gcp";
-        public const string KeyValue = "secret";
+        public const string KeyValueV2 = "secret";
+        public const string KeyValueV1 = "kv";
         public const string Identity = "identity";
         public const string Nomad = "nomad";
         public const string PKI = "pki";


### PR DESCRIPTION
The default mount for v1 kv is "kv", v2 is "secret".   Since there are separate apis for v1 vs v2 kv, makes sense to default the mount point accordingly.  
https://www.vaultproject.io/docs/secrets/kv/kv-v2.html