### PR TITLE
Fixed CAChainContent (ca_chain) property in AbstractCertificateData

### DIFF
--- a/src/VaultSharp/V1/SecretsEngines/PKI/AbstractCertificateData.cs
+++ b/src/VaultSharp/V1/SecretsEngines/PKI/AbstractCertificateData.cs
@@ -41,7 +41,7 @@ namespace VaultSharp.V1.SecretsEngines.PKI
         /// The content of the ca chain.
         /// </value>
         [JsonProperty("ca_chain")]
-        public string CAChainContent { get; set; }
+        public string[] CAChainContent { get; set; }
 
         /// <summary>
         /// Gets or sets the serial number.


### PR DESCRIPTION
When issuing a new certificate (PKI engine), an exception is thrown because the JSON response contains an array of type string for the ca_chain field, while the client is trying to deserialize this to a property of type string. Modified the CAChainContent property in AbstractCertificateData, so that it is now expecting an array of strings. 

Issue was also reported in #67 .