### PR TITLE
added httpClient to Vault client ctor

### DIFF
--- a/src/VaultSharp/VaultClient.cs
+++ b/src/VaultSharp/VaultClient.cs
@@ -1,6 +1,6 @@
 ﻿using VaultSharp.Core;
-using VaultSharp.V1.Commons;
 using VaultSharp.V1;
+using System.Net.Http;
 
 namespace VaultSharp
 {
@@ -18,6 +18,17 @@ namespace VaultSharp
         public VaultClient(VaultClientSettings vaultClientSettings)
         {
             polymath = new Polymath(vaultClientSettings);
+            V1 = new VaultClientV1(polymath);
+        }
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="vaultClientSettings"></param>
+        /// <param name="httpClient"></param>
+        public VaultClient(VaultClientSettings vaultClientSettings, HttpClient httpClient)
+        {
+            polymath = new Polymath(vaultClientSettings, httpClient);
             V1 = new VaultClientV1(polymath);
         }
 


### PR DESCRIPTION
We need more correct way to use http client through HttpClient Factory. https://docs.microsoft.com/en-us/dotnet/architecture/microservices/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests

also this changes helps to ignore SSL exceptions https://github.com/rajanadar/VaultSharp/issues/110