### PR TITLE
Extended the TOTP secrets engine with the remaining API methods.

### DIFF
--- a/src/VaultSharp/V1/SecretsEngines/TOTP/ITOTPSecretsEngine.cs
+++ b/src/VaultSharp/V1/SecretsEngines/TOTP/ITOTPSecretsEngine.cs
@@ -46,5 +46,68 @@ namespace VaultSharp.V1.SecretsEngines.TOTP
         /// The secret with the <see cref="TOTPCode" /> as the data.
         /// </returns>
         Task<Secret<TOTPCodeValidity>> ValidateCodeAsync(string keyName, string code, string mountPoint = SecretsEngineDefaultPaths.TOTP, string wrapTimeToLive = null);
+
+        /// <summary>
+        /// Creates a new key definition where Vault acts as TOTP provider
+        /// </summary>
+        /// <param name="keyName"><para>[required]</para>
+        /// Specifies the name of the key to create credentials against.
+        /// </param>
+        /// <param name="issuer"><para>[required]</para>
+        /// Specifies the name of the key’s issuing organization.
+        /// </param>
+        /// <param name="accountName"><para>[required]</para>
+        /// Specifies the name of the account associated with the key.
+        /// </param>
+        /// <param name="mountPoint"><para>[optional]</para>
+        /// The mount point for the Nomad backend. Defaults to <see cref="SecretsEngineDefaultPaths.TOTP" />
+        /// Provide a value only if you have customized the Nomad mount point.</param>
+        /// <returns>
+        /// The secret with the <see cref="TOTPProvider" /> as the data.
+        /// </returns>
+        Task<Secret<TOTPProvider>> CreateTOTPProviderKeyAsync(string keyName, string issuer, string accountName, string mountPoint = SecretsEngineDefaultPaths.TOTP);
+
+        /// <summary>
+        /// Deletes the key definition
+        /// </summary>
+        /// <param name="keyName"><para>[required]</para>
+        /// Specifies the name of the key to create credentials against.
+        /// </param>
+        /// <param name="mountPoint"><para>[optional]</para>
+        /// The mount point for the Nomad backend. Defaults to <see cref="SecretsEngineDefaultPaths.TOTP" />
+        /// Provide a value only if you have customized the Nomad mount point.</param>
+        /// <returns>A completed task when succesful</returns>
+        Task DeleteKeyAsync(string keyName, string mountPoint = SecretsEngineDefaultPaths.TOTP);
+
+        /// <summary>
+        /// Returns a list of available keys. Only the key names are returned, not any values.
+        /// </summary>
+        /// <param name="mountPoint"><para>[optional]</para>
+        /// The mount point for the Generic backend. Defaults to <see cref="SecretsEngineDefaultPaths.TOTP" />
+        /// Provide a value only if you have customized the mount point.</param>
+        /// <param name="wrapTimeToLive">
+        /// <para>[optional]</para>
+        /// The TTL for the token and can be either an integer number of seconds or a string duration of seconds.
+        /// </param>
+        /// <returns>List of availble keys</returns>
+        Task<Secret<ListInfo>> ListAllKeysAsync(string mountPoint = SecretsEngineDefaultPaths.TOTP, string wrapTimeToLive = null);
+
+        /// <summary>
+        /// Queries the key definition
+        /// </summary>
+        /// <param name="keyName"><para>[required]</para>
+        /// Specifies the name of the key to create credentials against.
+        /// </param>
+        /// <param name="mountPoint"><para>[optional]</para>
+        /// The mount point for the Nomad backend. Defaults to <see cref="SecretsEngineDefaultPaths.TOTP" />
+        /// Provide a value only if you have customized the Nomad mount point.</param>
+        /// <param name="wrapTimeToLive">
+        /// <para>[optional]</para>
+        /// The TTL for the token and can be either an integer number of seconds or a string duration of seconds.
+        /// </param>
+        /// <returns>A secret with the key definition</returns>
+        Task<Secret<TOTPKey>> ReadKeyAsync(string keyName, string mountPoint = SecretsEngineDefaultPaths.TOTP, string wrapTimeToLive = null);
+
+
     }
 }

--- a/src/VaultSharp/V1/SecretsEngines/TOTP/TOTPCode.cs
+++ b/src/VaultSharp/V1/SecretsEngines/TOTP/TOTPCode.cs
@@ -8,7 +8,7 @@ namespace VaultSharp.V1.SecretsEngines.TOTP
     public class TOTPCode
     {
         /// <summary>
-        /// Gets or sets the TOTO code.
+        /// Gets or sets the TOTP code.
         /// </summary>
         /// <value>
         /// The TOTP code.

--- a/src/VaultSharp/V1/SecretsEngines/TOTP/TOTPKey.cs
+++ b/src/VaultSharp/V1/SecretsEngines/TOTP/TOTPKey.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace VaultSharp.V1.SecretsEngines.TOTP
+{
+    /// <summary>
+    /// Represents a queried key
+    /// </summary>
+    public class TOTPKey
+    {
+        /// <summary>
+        /// Gets or sets the name of the account associated with the key.
+        /// </summary>
+        [JsonProperty("account_name")]
+        public string AccountName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the used hashing algorithm.
+        /// </summary>
+        [JsonProperty("algorithm")]
+        public string Algorithm { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the issuing organization.
+        /// </summary>
+        [JsonProperty("issuer")]
+        public string Issuer { get; set; }
+
+        /// <summary>
+        /// Gets or sets the length of time in seconds used to
+        /// create a counter for the TOTP code calculation.
+        /// </summary>
+        [JsonProperty("period")]
+        public string Period { get; set; }
+    }
+}

--- a/src/VaultSharp/V1/SecretsEngines/TOTP/TOTPProvider.cs
+++ b/src/VaultSharp/V1/SecretsEngines/TOTP/TOTPProvider.cs
@@ -1,0 +1,31 @@
+﻿using Newtonsoft.Json;
+
+namespace VaultSharp.V1.SecretsEngines.TOTP
+{
+    /// <summary>
+    /// Represents the result when creating a new key
+    /// </summary>
+    public class TOTPProvider
+    {
+        /// <summary>
+        /// Gets or sets the Barcode
+        /// </summary>
+        /// <remarks>
+        /// If a QR code is returned, it consists of base64-formatted PNG bytes.
+        /// You can embed it in a web page by including the base64 string
+        /// in an 'img'-tag with the prefix data:image/png;base64
+        /// </remarks>
+        [JsonProperty("barcode")]
+        public string Barcode { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Url
+        /// </summary>
+        /// <remarks>
+        /// The Url can be used by the client application in order to create
+        /// TOTP codes.
+        /// </remarks>
+        [JsonProperty("url")]
+        public string Url { get; set; }
+    }
+}

--- a/src/VaultSharp/V1/SecretsEngines/TOTP/TOTPSecretsEngineProvider.cs
+++ b/src/VaultSharp/V1/SecretsEngines/TOTP/TOTPSecretsEngineProvider.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Http;
+﻿using System.Collections.Generic;
+using System.Net.Http;
 using System.Threading.Tasks;
 using VaultSharp.Core;
 using VaultSharp.V1.Commons;
@@ -14,12 +15,52 @@ namespace VaultSharp.V1.SecretsEngines.TOTP
             _polymath = polymath;
         }
 
+        public async Task<Secret<TOTPProvider>> CreateTOTPProviderKeyAsync(string keyName, string issuer, string accountName, string mountPoint = SecretsEngineDefaultPaths.TOTP)
+        {
+            Checker.NotNull(mountPoint, "mountPoint");
+            Checker.NotNull(keyName, "keyName");
+            Checker.NotNull(issuer, "issuer");
+            Checker.NotNull(accountName, "accountName");
+
+            var values = new Dictionary<string, object>()
+            {
+                ["generate"] = true,
+                ["issuer"] = issuer,
+                ["account_name"] = accountName
+            };
+
+            return await _polymath.MakeVaultApiRequest<Secret<TOTPProvider>>("v1/" + mountPoint.Trim('/') + "/keys/" + keyName.Trim('/'), HttpMethod.Post, requestData: values).ConfigureAwait(_polymath.VaultClientSettings.ContinueAsyncTasksOnCapturedContext);
+        }
+
+        public async Task DeleteKeyAsync(string keyName, string mountPoint = "totp")
+        {
+            Checker.NotNull(mountPoint, "mountPoint");
+            Checker.NotNull(keyName, "keyName");
+
+            await _polymath.MakeVaultApiRequest<Secret<TOTPProvider>>("v1/" + mountPoint.Trim('/') + "/keys/" + keyName.Trim('/'), HttpMethod.Delete).ConfigureAwait(_polymath.VaultClientSettings.ContinueAsyncTasksOnCapturedContext);
+        }
+
         public async Task<Secret<TOTPCode>> GetCodeAsync(string keyName, string mountPoint = SecretsEngineDefaultPaths.TOTP, string wrapTimeToLive = null)
         {
             Checker.NotNull(mountPoint, "mountPoint");
             Checker.NotNull(keyName, "keyName");
 
             return await _polymath.MakeVaultApiRequest<Secret<TOTPCode>>("v1/" + mountPoint.Trim('/') + "/code/" + keyName.Trim('/'), HttpMethod.Get, wrapTimeToLive: wrapTimeToLive).ConfigureAwait(_polymath.VaultClientSettings.ContinueAsyncTasksOnCapturedContext);
+        }
+
+        public async Task<Secret<TOTPKey>> ReadKeyAsync(string keyName, string mountPoint = SecretsEngineDefaultPaths.TOTP, string wrapTimeToLive = null)
+        {
+            Checker.NotNull(mountPoint, "mountPoint");
+            Checker.NotNull(keyName, "keyName");
+
+            return await _polymath.MakeVaultApiRequest<Secret<TOTPKey>>("v1/" + mountPoint.Trim('/') + "/keys/" + keyName.Trim('/'), HttpMethod.Get, wrapTimeToLive: wrapTimeToLive).ConfigureAwait(_polymath.VaultClientSettings.ContinueAsyncTasksOnCapturedContext);
+        }
+
+        public async Task<Secret<ListInfo>> ListAllKeysAsync(string mountPoint = SecretsEngineDefaultPaths.TOTP, string wrapTimeToLive = null)
+        {
+            Checker.NotNull(mountPoint, "mountPoint");
+
+            return await _polymath.MakeVaultApiRequest<Secret<ListInfo>>("v1/" + mountPoint.Trim('/') + "/keys", HttpMethod.Get, wrapTimeToLive: wrapTimeToLive).ConfigureAwait(_polymath.VaultClientSettings.ContinueAsyncTasksOnCapturedContext);
         }
 
         public async Task<Secret<TOTPCodeValidity>> ValidateCodeAsync(string keyName, string code, string mountPoint = SecretsEngineDefaultPaths.TOTP, string wrapTimeToLive = null)


### PR DESCRIPTION
Extended the TOTP secrets engine with the remaining API methods in order to create Vault TOTP Provider keys from code.

Docs: https://www.vaultproject.io/docs/secrets/totp/index.html#as-a-provider
API Docs: https://www.vaultproject.io/api/secret/totp/index.html
