### PR TITLE
AWS.GenerateSTSCredentialsAsync() should use GET instead of POST (according to vault docs)

### DIFF
--- a/src/VaultSharp/V1/SecretsEngines/AWS/AWSSecretsEngineProvider.cs
+++ b/src/VaultSharp/V1/SecretsEngines/AWS/AWSSecretsEngineProvider.cs
@@ -29,7 +29,7 @@ namespace VaultSharp.V1.SecretsEngines.AWS
 
             object requestData = string.IsNullOrWhiteSpace(timeToLive) ? null : new { ttl = timeToLive };
 
-            return await _polymath.MakeVaultApiRequest<Secret<AWSCredentials>>("v1/" + awsMountPoint.Trim('/') + "/sts/" + awsRoleName.Trim('/'), HttpMethod.Post, requestData, wrapTimeToLive: wrapTimeToLive).ConfigureAwait(_polymath.VaultClientSettings.ContinueAsyncTasksOnCapturedContext);
+            return await _polymath.MakeVaultApiRequest<Secret<AWSCredentials>>("v1/" + awsMountPoint.Trim('/') + "/sts/" + awsRoleName.Trim('/'), HttpMethod.Get, requestData, wrapTimeToLive: wrapTimeToLive).ConfigureAwait(_polymath.VaultClientSettings.ContinueAsyncTasksOnCapturedContext);
         }
 
         public async Task<Secret<ListInfo>> ReadAllRolesAsync(string awsMountPoint = SecretsEngineDefaultPaths.AWS, string wrapTimeToLive = null)


### PR DESCRIPTION
Turns out `VaultSharp` is using a non-standard access method for generating AWS STS access tokens. The documentation says `GET` https://www.vaultproject.io/api-docs/secret/aws#generate-credentials but `VaultSharp` today uses a `POST` call