### PR TITLE
Copy IDictionary into Dictionary to remove infinite recursion

### DIFF
--- a/src/VaultSharp/V1/SecretsEngines/KeyValue/V1/KeyValueSecretsEngineV1Provider.cs
+++ b/src/VaultSharp/V1/SecretsEngines/KeyValue/V1/KeyValueSecretsEngineV1Provider.cs
@@ -38,7 +38,7 @@ namespace VaultSharp.V1.SecretsEngines.KeyValue.V1
 
         public async Task<Secret<Dictionary<string, object>>> WriteSecretAsync(string path, IDictionary<string, object> values, string mountPoint = SecretsEngineDefaultPaths.KeyValueV1)
         {
-            return await WriteSecretAsync(path, values, mountPoint);
+            return await WriteSecretAsync(path, new Dictionary<string, object>(values), mountPoint);
         }
         
         public async Task<Secret<T>> WriteSecretAsync<T>(string path, T values, string mountPoint = SecretsEngineDefaultPaths.KeyValueV1)


### PR DESCRIPTION
I run into a problem that VaultSharp was just hanging when I tried to write a secret. I believe this is a reason (VS 2019/ReSharper should also give you a warning about this). 