### PR TITLE
Fixed case then VAULT_ADDR has a trailing slash

### DIFF
--- a/src/VaultSharp/Core/Polymath.cs
+++ b/src/VaultSharp/Core/Polymath.cs
@@ -132,7 +132,7 @@ namespace VaultSharp.Core
         {
             try
             {
-                var requestUri = new Uri(_httpClient.BaseAddress, resourcePath);
+                var requestUri = new Uri(_httpClient.BaseAddress, new Uri(resourcePath, UriKind.Relative));
 
                 var requestContent = requestData != null
                     ? new StringContent(JsonConvert.SerializeObject(requestData), Encoding.UTF8)


### PR DESCRIPTION
Hey, recently I spend almost half a day trying to understand why I can't read from Vault and the problem was that I had a trailing slash in my VAULT_ADDR path. I fixed this problem using another Url constructor that is able to fix the URL internally.