### PR TITLE
README.md typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1088,7 +1088,7 @@ response.Data.EncodedItems;
 ```cs
 var decodeOptions = new DecodeRequestOptions { Value = "ipsem" };
 Secret<DecodedResponse> response = await _authenticatedVaultClient.V1.Secrets.Transform.DecodeAsync(roleName, decodeOptions);
-response.Data.DecodedText;
+response.Data.DecodedValuet;
 ```
 
 ###### Decode Batched Item

--- a/README.md
+++ b/README.md
@@ -1078,7 +1078,7 @@ var encodeOptions = new EncodeRequestOptions
 };
 
 Secret<EncodedResponse> response = await _authenticatedVaultClient.V1.Secrets.Transform.EncodeAsync(roleName, encodeOptions);
-response.Data.BatchResults;
+response.Data.EncodedItems;
 ```
 
 ##### Decode Method

--- a/README.md
+++ b/README.md
@@ -1064,7 +1064,7 @@ await vaultClient.V1.Secrets.TOTP.DeleteKeyAsync(keyName);
 ```cs
 
 var encodeOptions = new EncodeRequestOptions { Value = "ipsem" };
-Secret<EncodedResponse> response = await _authenticatedVaultClient.V1.Secrets.Transit.EncodeAsync(roleName, encodeOptions);
+Secret<EncodedResponse> response = await _authenticatedVaultClient.V1.Secrets.Transform.EncodeAsync(roleName, encodeOptions);
 response.Data.EncodedText;
 
 ```
@@ -1077,7 +1077,7 @@ var encodeOptions = new EncodeRequestOptions
   BatchItems = new List<EncodingItem> { new EncodingItem { Value = "ipsem1" }, new EncodingItem { Value = "ipsem2" } }
 };
 
-Secret<EncodedResponse> response = await _authenticatedVaultClient.V1.Secrets.Transit.EncodeAsync(roleName, encodeOptions);
+Secret<EncodedResponse> response = await _authenticatedVaultClient.V1.Secrets.Transform.EncodeAsync(roleName, encodeOptions);
 response.Data.BatchResults;
 ```
 
@@ -1087,7 +1087,7 @@ response.Data.BatchResults;
 
 ```cs
 var decodeOptions = new DecodeRequestOptions { Value = "ipsem" };
-Secret<DecodedResponse> response = await _authenticatedVaultClient.V1.Secrets.Transit.DecodeAsync(roleName, decodeOptions);
+Secret<DecodedResponse> response = await _authenticatedVaultClient.V1.Secrets.Transform.DecodeAsync(roleName, decodeOptions);
 response.Data.DecodedText;
 ```
 
@@ -1099,7 +1099,7 @@ var decodeOptions = new DecodeRequestOptions
   BatchItems = new List<DecodingItem> { new DecodingItem { Value = "ipsem1" }, new DecodingItem { Value = "ipsem2" } }
 };
 
-Secret<DecodedResponse> response = await _authenticatedVaultClient.V1.Secrets.Transit.DecodeAsync(roleName, decodeOptions);
+Secret<DecodedResponse> response = await _authenticatedVaultClient.V1.Secrets.Transform.DecodeAsync(roleName, decodeOptions);
 response.Data.BatchResults;
 ```
 

--- a/README.md
+++ b/README.md
@@ -1088,7 +1088,7 @@ response.Data.EncodedItems;
 ```cs
 var decodeOptions = new DecodeRequestOptions { Value = "ipsem" };
 Secret<DecodedResponse> response = await _authenticatedVaultClient.V1.Secrets.Transform.DecodeAsync(roleName, decodeOptions);
-response.Data.DecodedValuet;
+response.Data.DecodedValue;
 ```
 
 ###### Decode Batched Item

--- a/README.md
+++ b/README.md
@@ -1100,7 +1100,7 @@ var decodeOptions = new DecodeRequestOptions
 };
 
 Secret<DecodedResponse> response = await _authenticatedVaultClient.V1.Secrets.Transform.DecodeAsync(roleName, decodeOptions);
-response.Data.BatchResults;
+response.Data.DecodedItems;
 ```
 
 #### Transit Secrets Engine

--- a/README.md
+++ b/README.md
@@ -1065,7 +1065,7 @@ await vaultClient.V1.Secrets.TOTP.DeleteKeyAsync(keyName);
 
 var encodeOptions = new EncodeRequestOptions { Value = "ipsem" };
 Secret<EncodedResponse> response = await _authenticatedVaultClient.V1.Secrets.Transform.EncodeAsync(roleName, encodeOptions);
-response.Data.EncodedText;
+response.Data.EncodedValue;
 
 ```
 


### PR DESCRIPTION
The Transform Secrets Engine examples are using ".Transit" instead of ".Transform"

Edit: Noticed some more typos in the related property names