### PR TITLE
Changed type of property Expiration in CertificateCredentials from int to long

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.7.1.1 (September 14th, 2021)
+
+**IMPROVEMENTS:**
+
+  * Changed type of property ```Expiration``` in ```CertificateCredentials``` from ```int``` to ```long```.
+
 ## 1.7.1 (September 10, 2021)
 
 **BREAKING CHANGES:**

--- a/src/VaultSharp/V1/SecretsEngines/PKI/CertificateCredentials.cs
+++ b/src/VaultSharp/V1/SecretsEngines/PKI/CertificateCredentials.cs
@@ -32,6 +32,6 @@ namespace VaultSharp.V1.SecretsEngines.PKI
         /// The expiration.
         /// </value>
         [JsonProperty("expiration")]
-        public int Expiration { get; set; }
+        public long Expiration { get; set; }
     }
 }

--- a/src/VaultSharp/VaultSharp.csproj
+++ b/src/VaultSharp/VaultSharp.csproj
@@ -6,7 +6,7 @@
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>VaultSharp.snk</AssemblyOriginatorKeyFile>
     <Title>VaultSharp</Title>
-    <Version>1.7.1</Version>
+    <Version>1.7.1.1</Version>
     <Authors>Raja Nadar</Authors>
     <Copyright>Copyright ©  2021 Raja Nadar. All rights reserved.</Copyright>
     <PackageProjectUrl>https://github.com/rajanadar/VaultSharp</PackageProjectUrl>
@@ -22,8 +22,8 @@
 This library is built with .NET Standard 1.3, .NET Standard 2.0, .NET Standard 2.1, .NET Framework 4.5 4.6, 4.6.*, 4.7, 4.7.*, 4.8  &amp; .NET 5 and hence is cross-platform across .NET Core 1.x, 2.x, 3.x, .NET Frameworks 4.x, Xamarin iOS, Android, Mac, UWP etc.</Description>
     <RepositoryType>Github</RepositoryType>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>1.7.1.0</AssemblyVersion>
-    <FileVersion>1.7.1.0</FileVersion>
+    <AssemblyVersion>1.7.1.1</AssemblyVersion>
+    <FileVersion>1.7.1.1</FileVersion>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageIcon>icon.png</PackageIcon>
     


### PR DESCRIPTION
Since it represents an epoch timestamp, int will cause issues after year 2038. According to the vault source code, the expiration value is int64: https://github.com/hashicorp/vault/blob/main/builtin/logical/pki/path_issue_sign.go#L246