### PR TITLE
Updated Github Pages link to use https

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The most comprehensive cross-platform .NET Library for HashiCorp's Vault - A Sec
 
 **VaultSharp NuGet:** [![NuGet](https://img.shields.io/nuget/dt/VaultSharp.svg?style=flat)](https://www.nuget.org/packages/VaultSharp)
 
-**VaultSharp Latest Documentation:** Inline Below and also at: http://rajanadar.github.io/VaultSharp/
+**VaultSharp Latest Documentation:** Inline Below and also at: https://rajanadar.github.io/VaultSharp/
 
 **VaultSharp Questions/Clarifications:** [Ask on Stack Overflow with the tag vaultsharp](https://stackoverflow.com/questions/tagged/vaultsharp)
 


### PR DESCRIPTION
Changed Github Pages documentation link from http -> https in readme file.

Also under the about section of the project, the link provided there also is http and not https:
![image](https://user-images.githubusercontent.com/22691956/184978280-a5c612d2-9b37-43cc-9dd7-81ee505d52ee.png)
If wanted you can enforce https in the settings: [Securing your GitHub Pages site with HTTPS](https://docs.github.com/en/pages/getting-started-with-github-pages/securing-your-github-pages-site-with-https)


Thanks