### PR TITLE
Add support for the Vault RabbitMQ endpoints 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1123,9 +1123,26 @@ Assert.NotNull(caCert.CertificateContent);
 - This endpoint generates a new set of dynamic credentials based on the named role.
 
 ```cs
-Secret<UsernamePasswordCredentials> secret = await vaultClient.V1.Secrets.RabbitMQ.GetCredentialsAsync(role);
+Secret<UsernamePasswordCredentials> secret = await vaultClient.V1.Secrets.RabbitMQ.GetCredentialsAsync(roleName);
 string username = secret.Data.Username;
 string password = secret.Data.Password;
+```
+
+##### Create, Read and Delete RabbitMQ Roles
+
+- These endpoints manage the creation, reading and deletion of RabbitMQ roles.
+
+```cs
+var virtualHostName = "/";
+var virtualHostPermission = new { write = ".*", read = ".*" };
+var virtualHosts = new Dictionary<string, object>() { { virtualHostName, virtualHostPermission } };
+var virtualHostsJson = JsonSerializer.Serialize(virtualHosts);
+var role = new RabbitMQRole() { VHosts = virtualHostsJson }        
+await vaultClient.V1.Secrets.RabbitMQ.CreateRoleAsync(roleName, role, mountPoint);
+
+await vaultClient.V1.Secrets.RabbitMQ.ReadRoleAsync(roleName, mountPoint);
+
+await vaultClient.V1.Secrets.RabbitMQ.DeleteRoleAsync(roleName, mountPoint);
 ```
 
 #### SSH Secrets Engine

--- a/src/VaultSharp/V1/SecretsEngines/RabbitMQ/IRabbitMQSecretsEngine.cs
+++ b/src/VaultSharp/V1/SecretsEngines/RabbitMQ/IRabbitMQSecretsEngine.cs
@@ -24,5 +24,52 @@ namespace VaultSharp.V1.SecretsEngines.RabbitMQ
         /// The secret with the <see cref="UsernamePasswordCredentials" /> as the data.
         /// </returns>
         Task<Secret<UsernamePasswordCredentials>> GetCredentialsAsync(string roleName, string mountPoint = null, string wrapTimeToLive = null);
+
+        /// <summary>
+        /// Configures the lease settings for generated credentials.
+        /// </summary>
+        /// <param name="lease"><para>[required]</para>
+        /// The lease settings.
+        /// </param>
+        /// <param name="mountPoint"><para>[optional]</para>
+        /// The mount point for the backend. Defaults to <see cref="SecretsEngineMountPoints.RabbitMQ" />
+        /// Provide a value only if you have customized the mount point.</param>
+        Task ConfigureLeaseAsync(RabbitMQLease lease, string mountPoint = null);
+
+        /// <summary>
+        /// Creates or updates the role definition.
+        /// </summary>
+        /// <param name="roleName"><para>[required]</para>
+        /// Specifies the name of the role to create.</param>
+        /// <param name="role"><para>[required]</para>
+        /// The role definition to be created.
+        /// </param>
+        /// <param name="mountPoint"><para>[optional]</para>
+        /// The mount point for the backend. Defaults to <see cref="SecretsEngineMountPoints.RabbitMQ" />
+        /// Provide a value only if you have customized the mount point.</param>
+        Task CreateRoleAsync(string roleName, RabbitMQRole role, string mountPoint = null);
+
+        /// <summary>
+        /// Queries the role definition.
+        /// </summary>
+        /// <param name="roleName"><para>[required]</para>
+        /// Specifies the name of the role to read.</param>
+        /// <param name="mountPoint"><para>[optional]</para>
+        /// The mount point for the backend. Defaults to <see cref="SecretsEngineMountPoints.RabbitMQ" />
+        /// Provide a value only if you have customized the mount point.</param>
+        /// <returns>
+        /// The secret with the <see cref="RabbitMQRole" /> as the data.
+        /// </returns>
+        Task<Secret<RabbitMQRole>> ReadRoleAsync(string roleName, string mountPoint = null);
+
+        /// <summary>
+        /// Deletes the role definition.
+        /// </summary>
+        /// <param name="roleName"><para>[required]</para>
+        /// Specifies the name of the role to create.</param>
+        /// <param name="mountPoint"><para>[optional]</para>
+        /// The mount point for the backend. Defaults to <see cref="SecretsEngineMountPoints.RabbitMQ" />
+        /// Provide a value only if you have customized the mount point.</param>
+        Task DeleteRoleAsync(string roleName, string mountPoint = null);
     }
 }

--- a/src/VaultSharp/V1/SecretsEngines/RabbitMQ/RabbitMQLease.cs
+++ b/src/VaultSharp/V1/SecretsEngines/RabbitMQ/RabbitMQLease.cs
@@ -1,0 +1,23 @@
+﻿using Newtonsoft.Json;
+
+namespace VaultSharp.V1.SecretsEngines.RabbitMQ
+{
+    public class RabbitMQLease
+    {
+
+        /// <summary>
+        /// Specifies the lease ttl provided in seconds.
+        /// </summary>
+        /// <value>
+        /// The time to live.
+        /// </value>
+        [JsonProperty("ttl")]
+        public int TimeToLive { get; set; }
+
+        /// <summary>
+        /// Specifies the maximum ttl provided in seconds.
+        /// </summary>
+        [JsonProperty("max_ttl")]
+        public int MaximumTimeToLive { get; set; }
+    }
+}

--- a/src/VaultSharp/V1/SecretsEngines/RabbitMQ/RabbitMQRole.cs
+++ b/src/VaultSharp/V1/SecretsEngines/RabbitMQ/RabbitMQRole.cs
@@ -1,0 +1,38 @@
+﻿using Newtonsoft.Json;
+
+namespace VaultSharp.V1.SecretsEngines.RabbitMQ
+{
+    public class RabbitMQRole
+    {
+        /// <summary>
+        /// Specifies a comma-separated RabbitMQ management tags
+        /// </summary>
+        /// <value>
+        /// The tags
+        /// </value>
+        [JsonProperty("tags")] 
+        public string Tags { get; set; }
+
+        /// <summary>
+        /// Specifies a map of virtual hosts to permissions. 
+        /// This can be base64-encoded to avoid string escaping.
+        /// See https://developer.hashicorp.com/vault/api-docs/secret/rabbitmq#create-role for examples
+        /// </summary>
+        /// <value>
+        /// The virtual hosts role.
+        /// </value>
+        [JsonProperty("vhosts")]
+        public string VHosts { get; set; }
+
+        /// <summary>
+        /// Specifies a map of virtual hosts and exchanges to topic permissions. This option requires RabbitMQ 3.7.0 or later. 
+        /// This can be base64-encoded to avoid string escaping.
+        /// See https://developer.hashicorp.com/vault/api-docs/secret/rabbitmq#create-role for examples
+        /// </summary>
+        /// <value>
+        /// The virtual hosts topics.
+        /// </value>
+        [JsonProperty("vhost_topics")]
+        public string VHostTopics { get; set; }
+    }
+}

--- a/src/VaultSharp/V1/SecretsEngines/RabbitMQ/RabbitMQSecretsEngineProvider.cs
+++ b/src/VaultSharp/V1/SecretsEngines/RabbitMQ/RabbitMQSecretsEngineProvider.cs
@@ -20,5 +20,34 @@ namespace VaultSharp.V1.SecretsEngines.RabbitMQ
 
             return await _polymath.MakeVaultApiRequest<Secret<UsernamePasswordCredentials>>(mountPoint ?? _polymath.VaultClientSettings.SecretsEngineMountPoints.RabbitMQ, "/creds/" + roleName.Trim('/'), HttpMethod.Get, wrapTimeToLive: wrapTimeToLive).ConfigureAwait(_polymath.VaultClientSettings.ContinueAsyncTasksOnCapturedContext);
         }
+
+        public async Task ConfigureLeaseAsync(RabbitMQLease lease, string mountPoint = null)
+        {
+            Checker.NotNull(lease, "lease");
+
+            await _polymath.MakeVaultApiRequest(mountPoint ?? _polymath.VaultClientSettings.SecretsEngineMountPoints.RabbitMQ, "/config/lease", HttpMethod.Post).ConfigureAwait(_polymath.VaultClientSettings.ContinueAsyncTasksOnCapturedContext);
+        }
+
+        public async Task CreateRoleAsync(string roleName, RabbitMQRole role, string mountPoint = null)
+        {
+            Checker.NotNull(roleName, "roleName");
+            Checker.NotNull(role, "role");
+
+            await _polymath.MakeVaultApiRequest(mountPoint ?? _polymath.VaultClientSettings.SecretsEngineMountPoints.RabbitMQ, "/roles/" + roleName.Trim('/'), HttpMethod.Post, role).ConfigureAwait(_polymath.VaultClientSettings.ContinueAsyncTasksOnCapturedContext);
+        }
+
+        public async Task<Secret<RabbitMQRole>> ReadRoleAsync(string roleName, string mountPoint = null)
+        {
+            Checker.NotNull(roleName, "roleName");
+
+            return await _polymath.MakeVaultApiRequest<Secret<RabbitMQRole>>(mountPoint ?? _polymath.VaultClientSettings.SecretsEngineMountPoints.RabbitMQ, "/roles/" + roleName.Trim('/'), HttpMethod.Get).ConfigureAwait(_polymath.VaultClientSettings.ContinueAsyncTasksOnCapturedContext);
+        }
+
+        public async Task DeleteRoleAsync(string roleName, string mountPoint = null)
+        {
+            Checker.NotNull(roleName, "roleName");
+
+            await _polymath.MakeVaultApiRequest(mountPoint ?? _polymath.VaultClientSettings.SecretsEngineMountPoints.RabbitMQ, "/roles/" + roleName.Trim('/'), HttpMethod.Delete).ConfigureAwait(_polymath.VaultClientSettings.ContinueAsyncTasksOnCapturedContext);
+        }
     }
 }


### PR DESCRIPTION
The endpoints of `ConfigureLease`, `CreateRole`, `ReadRole`, and `DeleteRole` as documented in the [API Docs](https://developer.hashicorp.com/vault/api-docs/secret/rabbitmq).

This is in support of [Issue 286](https://github.com/rajanadar/VaultSharp/issues/286)