### PR TITLE
kv2/metadata: `ReadSecretPathsAsync` allows empty path value to list all secrets on the `mountPoint`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
  * [GH-309](https://github.com/rajanadar/VaultSharp/issues/309) identity/oidc/role: create, read, update and delete apis.
  * [GH-309](https://github.com/rajanadar/VaultSharp/issues/309) auth/approle: ````PullNewSecretIdAsync``` allows for reponse wrapping using ```wrapTimeToLive``` parameter
  * [GH-329](https://github.com/rajanadar/VaultSharp/issues/329) kv2/metadata: `ReadSecretPathsAsync` to use HTTP `GET` method and `?list=true` instead of non-standard HTTP verb `LIST`
-
+ * [GH-334](https://github.com/rajanadar/VaultSharp/issues/334) kv2/metadata: `ReadSecretPathsAsync` allows empty path value to list all secrets on the `mountPoint`
 ## 1.13.0.1 (April 03, 2023)
 
 **BUG FIXES:**

--- a/src/VaultSharp/V1/SecretsEngines/KeyValue/V2/IKeyValueSecretsEngineV2.cs
+++ b/src/VaultSharp/V1/SecretsEngines/KeyValue/V2/IKeyValueSecretsEngineV2.cs
@@ -232,8 +232,10 @@ namespace VaultSharp.V1.SecretsEngines.KeyValue.V2
         /// Folders are suffixed with /. The input must be a folder; list on a file will not return a value. 
         /// The values themselves are not accessible via this API.
         /// </summary>
-        /// <param name="path"><para>[required]</para>
-        /// The location path where the secret needs to be read from.</param>
+        /// <param name="path">
+        /// The location path where the secret needs to be read from. Can be empty string or null, if you
+        /// want to list all secrets on the mount point.
+        /// </param>
         /// <param name="mountPoint"><para>[optional]</para>
         /// The mount point for the Generic backend. Defaults to <see cref="SecretsEngineMountPoints.KeyValueV2" />
         /// Provide a value only if you have customized the mount point.</param>

--- a/src/VaultSharp/V1/SecretsEngines/KeyValue/V2/KeyValueSecretsEngineV2Provider.cs
+++ b/src/VaultSharp/V1/SecretsEngines/KeyValue/V2/KeyValueSecretsEngineV2Provider.cs
@@ -108,11 +108,13 @@ namespace VaultSharp.V1.SecretsEngines.KeyValue.V2
 
         public async Task<Secret<ListInfo>> ReadSecretPathsAsync(string path, string mountPoint = null, string wrapTimeToLive = null)
         {
-            Checker.NotNull(path, "path");
-
+            string p = path ?? "";
+            if (p.Length > 0) {
+                p = p.Trim('/');
+            }
             string queryParameters = "?list=true";
 
-            return await _polymath.MakeVaultApiRequest<Secret<ListInfo>>(mountPoint ?? _polymath.VaultClientSettings.SecretsEngineMountPoints.KeyValueV2, "/metadata/" + path.Trim('/') + queryParameters, HttpMethod.Get, wrapTimeToLive: wrapTimeToLive).ConfigureAwait(_polymath.VaultClientSettings.ContinueAsyncTasksOnCapturedContext);
+            return await _polymath.MakeVaultApiRequest<Secret<ListInfo>>(mountPoint ?? _polymath.VaultClientSettings.SecretsEngineMountPoints.KeyValueV2, "/metadata/" + p + queryParameters, HttpMethod.Get, wrapTimeToLive: wrapTimeToLive).ConfigureAwait(_polymath.VaultClientSettings.ContinueAsyncTasksOnCapturedContext);
         }
 
         public async Task<Secret<FullSecretMetadata>> ReadSecretMetadataAsync(string path, string mountPoint = null, string wrapTimeToLive = null)


### PR DESCRIPTION
In the implementation of 
```
public async Task<Secret<ListInfo>> ReadSecretPathsAsync(string path, string mountPoint = null, string wrapTimeToLive = null)
```

the path is required which was built referencing -> https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2#list-secrets

However, as reported in gh-334, it seems like `path` can be empty, if you want to list all the secrets on the mount point.

I tried this with Vault v1.15.2, below are the results of my test.

**Sample Request**
```
curl --header "X-Vault-Token: …” --request LIST http://127.0.0.1:8200/v1/secret/metadata 
```
**Response**
```
{
  "request_id": "34a153dc-0fef-b717-25da-1f54e77ab581",
  "lease_id": "",
  "renewable": false,
  "lease_duration": 0,
  "data": {
    "keys": [
      "bye",
      "hello/",
      "world"
    ]
  },
  "wrap_info": null,
  "warnings": null,
  "auth": null
}
```

considering the above results, I felt removing the strict null check and adding a simple guard rail would be a better solution.

fixes #334 