### PR TITLE
Add new TransitKeyCategory

### DIFF
--- a/src/VaultSharp/V1/SecretsEngines/Transit/TransitKeyCategory.cs
+++ b/src/VaultSharp/V1/SecretsEngines/Transit/TransitKeyCategory.cs
@@ -10,6 +10,10 @@ namespace VaultSharp.V1.SecretsEngines.Transit
 
         signing_key = 2,
 
-        hmac_key = 3
+        hmac_key = 3,
+
+        public_key = 4,
+        
+        certificate_chain = 5
     }
 }

--- a/src/VaultSharp/V1/SecretsEngines/Transit/TransitKeyCategory.cs
+++ b/src/VaultSharp/V1/SecretsEngines/Transit/TransitKeyCategory.cs
@@ -14,6 +14,10 @@ namespace VaultSharp.V1.SecretsEngines.Transit
 
         public_key = 4,
         
-        certificate_chain = 5
+        certificate_chain = 5,
+        /// <summary>
+        /// Enterprise only
+        /// </summary>
+        cmac_key = 6
     }
 }


### PR DESCRIPTION
The public-key and certificate-chain transit key category were missing in the available list. This is specified in this doc [](https://developer.hashicorp.com/vault/api-docs/secret/transit#public-key)