### PR TITLE
Add PKI secrets engine management for issuers, keys, and roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1345,6 +1345,106 @@ var caCert = await vaultClient.V1.Secrets.PKI.ReadCACertificateAsync(Certificate
 Assert.NotNull(caCert.CertificateContent);
 ```
 
+##### List Issuers
+
+```cs
+var issuers = await vaultClient.V1.Secrets.PKI.Issuers.ListIssuers();
+List<string> issuerKeys = issuers.Data.Keys;
+```
+
+##### Add Issuer
+
+```cs
+var issuerData = new IssuerData { CommonName = "example.com", KeyType = PrivateKeyType.rsa, KeyBits = 4096 };
+Secret<IssuerResponseData> issuer = await vaultClient.V1.Secrets.PKI.Issuers.AddIssuer(issuerData);
+string issuerId = issuer.Data.IssuerId;
+```
+
+##### Read Issuer Config
+
+```cs
+Secret<IssuerConfigResponseData> config = await vaultClient.V1.Secrets.PKI.Issuers.GetIssuerConfigData("my-issuer");
+string issuerName = config.Data.IssuerName;
+```
+
+##### Configure Issuer
+
+```cs
+var configData = new IssuerConfigRequestData { IssuerName = "my-issuer", Usage = "issuing-certificates,crl-signing" };
+Secret<IssuerConfigResponseData> config = await vaultClient.V1.Secrets.PKI.Issuers.ConfigureIssuer(configData);
+string issuerId = config.Data.IssuerId;
+```
+
+##### Delete Issuer
+
+```cs
+await vaultClient.V1.Secrets.PKI.Issuers.DeleteIssuer("my-issuer");
+```
+
+##### List Keys
+
+```cs
+var keys = await vaultClient.V1.Secrets.PKI.Keys.ListKeys();
+List<string> keyIds = keys.Data.Keys;
+```
+
+##### Generate Key
+
+```cs
+var keyData = new KeyData { KeyType = PrivateKeyType.rsa, KeyBits = 4096, KeyName = "my-key" };
+Secret<KeyData> key = await vaultClient.V1.Secrets.PKI.Keys.GenerateKey(keyData);
+string keyName = key.Data.KeyName;
+```
+
+##### Read Key
+
+```cs
+Secret<KeyData> key = await vaultClient.V1.Secrets.PKI.Keys.GetKey("my-key");
+PrivateKeyType keyType = key.Data.KeyType;
+```
+
+##### Import Key
+
+```cs
+var importData = new ImportKeyData { KeyName = "my-key", PemBundle = "-----BEGIN RSA PRIVATE KEY-----\n..." };
+Secret<ImportKeyData> key = await vaultClient.V1.Secrets.PKI.Keys.ImportKey(importData);
+string keyName = key.Data.KeyName;
+```
+
+##### Delete Key
+
+```cs
+await vaultClient.V1.Secrets.PKI.Keys.DeleteKey("my-key");
+```
+
+##### List PKI Roles
+
+```cs
+var roles = await vaultClient.V1.Secrets.PKI.Roles.ListRoles();
+List<string> roleKeys = roles.Data.Keys;
+```
+
+##### Add PKI Role
+
+```cs
+var roleData = new RoleData { Name = "my-role", AllowedDomains = new List<string> { "example.com" }, AllowSubdomains = true };
+Secret<RoleData> role = await vaultClient.V1.Secrets.PKI.Roles.AddRole(roleData);
+PrivateKeyRoleType keyType = role.Data.KeyType;
+```
+
+##### Read PKI Role
+
+```cs
+Secret<RoleData> role = await vaultClient.V1.Secrets.PKI.Roles.GetRole("my-role");
+bool allowAnyName = role.Data.AllowAnyName;
+```
+
+##### Delete PKI Role
+
+```cs
+await vaultClient.V1.Secrets.PKI.Roles.DeleteRole("my-role");
+```
+
 #### RabbitMQ Secrets Engine
 
 ##### Generate dynamic DB credentials

--- a/src/VaultSharp/V1/SecretsEngines/PKI/ExtendedKeyUsageConstants.cs
+++ b/src/VaultSharp/V1/SecretsEngines/PKI/ExtendedKeyUsageConstants.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.Generic;
+
+namespace VaultSharp.V1.SecretsEngines.PKI
+{
+    public class ExtendedKeyUsageConstants
+    {
+        public const string Any = "Any";
+        public const string ServerAuth = "ServerAuth";
+        public const string ClientAuth = "ClientAuth";
+        public const string CodeSigning = "CodeSigning";
+        public const string EmailProtection = "EmailProtection";
+        public const string IPSECEndSystem = "IPSECEndSystem";
+        public const string IPSECTunnel = "IPSECTunnel";
+        public const string IPSECUser = "IPSECUser";
+        public const string TimeStamping = "TimeStamping";
+        public const string OCSPSigning = "OCSPSigning";
+        public const string MicrosoftServerGatedCrypto = "MicrosoftServerGatedCrypto";
+        public const string NetscapeServerGatedCrypto = "NetscapeServerGatedCrypto";
+        public const string MicrosoftCommercialCodeSigning = "MicrosoftCommercialCodeSigning";
+        public const string MicrosoftKernelCodeSigning = "MicrosoftKernelCodeSigning";
+
+        public static IReadOnlyList<string> DefaultSSLKeyUsages = new List<string>()
+        {
+            ServerAuth,
+            ClientAuth
+        };
+    }
+}

--- a/src/VaultSharp/V1/SecretsEngines/PKI/IPKISecretsEngine.cs
+++ b/src/VaultSharp/V1/SecretsEngines/PKI/IPKISecretsEngine.cs
@@ -1,6 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using VaultSharp.V1.Commons;
+using VaultSharp.V1.SecretsEngines.PKI.Issuers;
+using VaultSharp.V1.SecretsEngines.PKI.Keys;
+using VaultSharp.V1.SecretsEngines.PKI.Roles;
 
 namespace VaultSharp.V1.SecretsEngines.PKI
 {
@@ -9,6 +12,12 @@ namespace VaultSharp.V1.SecretsEngines.PKI
     /// </summary>
     public interface IPKISecretsEngine
     {
+        IPKIIssuers Issuers { get; }
+
+        IPKIKeys Keys { get; }
+
+        IPKIRoles Roles { get; }
+
         /// <summary>
         /// Generates a new set of credentials (private key and certificate) based on the role named in the endpoint.
         /// The issuing CA certificate is returned as well, so that only the root CA need be in a client's trust store.

--- a/src/VaultSharp/V1/SecretsEngines/PKI/Issuers/IPKIIssuers.cs
+++ b/src/VaultSharp/V1/SecretsEngines/PKI/Issuers/IPKIIssuers.cs
@@ -1,0 +1,20 @@
+﻿using System.Threading.Tasks;
+using VaultSharp.V1.Commons;
+
+namespace VaultSharp.V1.SecretsEngines.PKI.Issuers
+{
+    public interface IPKIIssuers
+    {
+        Task<Secret<KeysData>> ListIssuers(string pkiBackendMountPoint = null, string wrapTimeToLive = null);
+
+        Task<Secret<IssuerResponseData>> AddIssuer(IssuerData data, string pkiBackendMountPoint = null, string wrapTimeToLive = null);
+
+        Task<Secret<IssuerConfigResponseData>> GetIssuerConfigData(string issuerName,
+            string pkiBackendMountPoint = null, string wrapTimeToLive = null);
+
+        Task<Secret<IssuerConfigResponseData>> ConfigureIssuer(IssuerConfigRequestData data,
+            string pkiBackendMountPoint = null, string wrapTimeToLive = null);
+
+        Task DeleteIssuer(string issuerName, string pkiBackendMountPoint = null, string wrapTimeToLive = null);
+    }
+}

--- a/src/VaultSharp/V1/SecretsEngines/PKI/Issuers/IssuerConfigRequestData.cs
+++ b/src/VaultSharp/V1/SecretsEngines/PKI/Issuers/IssuerConfigRequestData.cs
@@ -1,0 +1,73 @@
+﻿using System.Collections.Generic;
+using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
+using System.Xml.Linq;
+
+namespace VaultSharp.V1.SecretsEngines.PKI.Issuers
+{
+    public class IssuerConfigRequestData
+    {
+        /// <summary>
+        /// Comma-separated list of URLs to be used for the CRL distribution points attribute. See also RFC 5280 Section 4.2.1.13.
+        /// </summary>
+        /// <value>Comma-separated list of URLs to be used for the CRL distribution points attribute. See also RFC 5280 Section 4.2.1.13.</value>
+        [JsonPropertyName("crl_distribution_points")]
+        public List<string> CrlDistributionPoints { get; set; }
+
+        /// <summary>
+        /// Whether or not to enabling templating of the above AIA fields. When templating is enabled the special values &#39;{{issuer_id}}&#39;, &#39;{{cluster_path}}&#39;, &#39;{{cluster_aia_path}}&#39; are available, but the addresses are not checked for URL validity until issuance time. Using &#39;{{cluster_path}}&#39; requires /config/cluster&#39;s &#39;path&#39; member to be set on all PR Secondary clusters and using &#39;{{cluster_aia_path}}&#39; requires /config/cluster&#39;s &#39;aia_path&#39; member to be set on all PR secondary clusters.
+        /// </summary>
+        /// <value>Whether or not to enabling templating of the above AIA fields. When templating is enabled the special values &#39;{{issuer_id}}&#39;, &#39;{{cluster_path}}&#39;, &#39;{{cluster_aia_path}}&#39; are available, but the addresses are not checked for URL validity until issuance time. Using &#39;{{cluster_path}}&#39; requires /config/cluster&#39;s &#39;path&#39; member to be set on all PR Secondary clusters and using &#39;{{cluster_aia_path}}&#39; requires /config/cluster&#39;s &#39;aia_path&#39; member to be set on all PR secondary clusters.</value>
+        [JsonPropertyName("enable_aia_url_templating")]
+        public bool EnableAiaUrlTemplating { get; set; }
+
+        /// <summary>
+        /// Provide a name to the generated or existing issuer, the name must be unique across all issuers and not be the reserved value &#39;default&#39;
+        /// </summary>
+        /// <value>Provide a name to the generated or existing issuer, the name must be unique across all issuers and not be the reserved value &#39;default&#39;</value>
+        [JsonPropertyName("issuer_name")]
+        public string IssuerName { get; set; }
+
+        /// <summary>
+        /// Comma-separated list of URLs to be used for the issuing certificate attribute. See also RFC 5280 Section 4.2.2.1.
+        /// </summary>
+        /// <value>Comma-separated list of URLs to be used for the issuing certificate attribute. See also RFC 5280 Section 4.2.2.1.</value>
+        [JsonPropertyName("issuing_certificates")]
+        public List<string> IssuingCertificates { get; set; } = new List<string>();
+
+        /// <summary>
+        /// Behavior of leaf&#39;s NotAfter fields: \&quot;err\&quot; to error if the computed NotAfter date exceeds that of this issuer; \&quot;truncate\&quot; to silently truncate to that of this issuer; or \&quot;permit\&quot; to allow this issuance to succeed (with NotAfter exceeding that of an issuer). Note that not all values will results in certificates that can be validated through the entire validity period. It is suggested to use \&quot;truncate\&quot; for intermediate CAs and \&quot;permit\&quot; only for root CAs.
+        /// </summary>
+        /// <value>Behavior of leaf&#39;s NotAfter fields: \&quot;err\&quot; to error if the computed NotAfter date exceeds that of this issuer; \&quot;truncate\&quot; to silently truncate to that of this issuer; or \&quot;permit\&quot; to allow this issuance to succeed (with NotAfter exceeding that of an issuer). Note that not all values will results in certificates that can be validated through the entire validity period. It is suggested to use \&quot;truncate\&quot; for intermediate CAs and \&quot;permit\&quot; only for root CAs.</value>
+        [JsonPropertyName("leaf_not_after_behavior")]
+        public string LeafNotAfterBehavior { get; set; }
+
+        /// <summary>
+        /// Chain of issuer references to use to build this issuer&#39;s computed CAChain field, when non-empty.
+        /// </summary>
+        /// <value>Chain of issuer references to use to build this issuer&#39;s computed CAChain field, when non-empty.</value>
+        [JsonPropertyName("manual_chain")]
+        public List<string> ManualChain { get; set; } = new List<string>();
+
+        /// <summary>
+        /// Comma-separated list of URLs to be used for the OCSP servers attribute. See also RFC 5280 Section 4.2.2.1.
+        /// </summary>
+        /// <value>Comma-separated list of URLs to be used for the OCSP servers attribute. See also RFC 5280 Section 4.2.2.1.</value>
+        [JsonPropertyName("ocsp_servers")]
+        public List<string> OcspServers { get; set; }
+
+        /// <summary>
+        /// Which x509.SignatureAlgorithm name to use for signing CRLs. This parameter allows differentiation between PKCS#1v1.5 and PSS keys and choice of signature hash algorithm. The default (empty string) value is for Go to select the signature algorithm. This can fail if the underlying key does not support the requested signature algorithm, which may not be known at modification time (such as with PKCS#11 managed RSA keys).
+        /// </summary>
+        /// <value>Which x509.SignatureAlgorithm name to use for signing CRLs. This parameter allows differentiation between PKCS#1v1.5 and PSS keys and choice of signature hash algorithm. The default (empty string) value is for Go to select the signature algorithm. This can fail if the underlying key does not support the requested signature algorithm, which may not be known at modification time (such as with PKCS#11 managed RSA keys).</value>
+        [JsonPropertyName("revocation_signature_algorithm")]
+        public string RevocationSignatureAlgorithm { get; set; }
+
+        /// <summary>
+        /// Comma-separated list (or string slice) of usages for this issuer; valid values are \&quot;read-only\&quot;, \&quot;issuing-certificates\&quot;, \&quot;crl-signing\&quot;, and \&quot;ocsp-signing\&quot;. Multiple values may be specified. Read-only is implicit and always set.
+        /// </summary>
+        /// <value>Comma-separated list (or string slice) of usages for this issuer; valid values are \&quot;read-only\&quot;, \&quot;issuing-certificates\&quot;, \&quot;crl-signing\&quot;, and \&quot;ocsp-signing\&quot;. Multiple values may be specified. Read-only is implicit and always set.</value>
+        [JsonPropertyName("usage")]
+        public string Usage { get; set; }
+    }
+}

--- a/src/VaultSharp/V1/SecretsEngines/PKI/Issuers/IssuerConfigResponseData.cs
+++ b/src/VaultSharp/V1/SecretsEngines/PKI/Issuers/IssuerConfigResponseData.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace VaultSharp.V1.SecretsEngines.PKI.Issuers
+{
+    public class IssuerConfigResponseData : IssuerConfigRequestData
+    {
+        [JsonPropertyName("ca_chain")] public List<string> CaChain { get; set; } = new List<string>();
+        [JsonPropertyName("certificate")] public string Certificate { get; set; }
+        [JsonPropertyName("issuer_id")] public string IssuerId { get; set; }
+        [JsonPropertyName("issuing_certificates")] public List<string> IssuingCertificates { get; set; } = new List<string>();
+        [JsonPropertyName("key_id")] public string KeyId { get; set; }
+        [JsonPropertyName("revoked")] public bool Revoked { get; set; }
+    }
+}

--- a/src/VaultSharp/V1/SecretsEngines/PKI/Issuers/IssuerData.cs
+++ b/src/VaultSharp/V1/SecretsEngines/PKI/Issuers/IssuerData.cs
@@ -1,0 +1,320 @@
+﻿using System.Collections.Generic;
+using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
+using System.Xml.Linq;
+
+namespace VaultSharp.V1.SecretsEngines.PKI.Issuers
+{
+    public class IssuerData
+    {
+        public IssuerData()
+        {
+            this.Format = IssuerFormat.pem;
+            this.ExcludeCnFromSans = false;
+            this.KeyRef = "default";
+            this.KeyType = PrivateKeyType.rsa;
+            this.MaxPathLength = -1;
+            this.NotBeforeDuration = "30";
+            this.PrivateKeyFormat = IssuerPrivateKeyFormat.pem;
+            this.UsePss = false;
+        }
+
+        /// <summary>
+        ///     Format for returned data. Can be \&quot;pem\&quot;, \&quot;der\&quot;, or \&quot;pem_bundle\&quot;. If \&quot;
+        ///     pem_bundle\&quot;, any private key and issuing cert will be appended to the certificate pem. If \&quot;der\&quot;,
+        ///     the value will be base64 encoded. Defaults to \&quot;pem\&quot;.
+        /// </summary>
+        /// <value>
+        ///     Format for returned data. Can be \&quot;pem\&quot;, \&quot;der\&quot;, or \&quot;pem_bundle\&quot;. If \&quot;
+        ///     pem_bundle\&quot;, any private key and issuing cert will be appended to the certificate pem. If \&quot;der\&quot;,
+        ///     the value will be base64 encoded. Defaults to \&quot;pem\&quot;.
+        /// </value>
+        [JsonPropertyName("format")]
+        public IssuerFormat? Format { get; set; }
+
+        /// <summary>
+        ///     The type of key to use; defaults to RSA. \&quot;rsa\&quot; \&quot;ec\&quot; and \&quot;ed25519\&quot; are the only
+        ///     valid values.
+        /// </summary>
+        /// <value>
+        ///     The type of key to use; defaults to RSA. \&quot;rsa\&quot; \&quot;ec\&quot; and \&quot;ed25519\&quot; are the
+        ///     only valid values.
+        /// </value>
+        [JsonPropertyName("key_type")]
+        public PrivateKeyType? KeyType { get; set; }
+
+        /// <summary>
+        ///     Format for the returned private key. Generally the default will be controlled by the \&quot;format\&quot; parameter
+        ///     as either base64-encoded DER or PEM-encoded DER. However, this can be set to \&quot;pkcs8\&quot; to have the
+        ///     returned private key contain base64-encoded pkcs8 or PEM-encoded pkcs8 instead. Defaults to \&quot;der\&quot;.
+        /// </summary>
+        /// <value>
+        ///     Format for the returned private key. Generally the default will be controlled by the \&quot;format\&quot;
+        ///     parameter as either base64-encoded DER or PEM-encoded DER. However, this can be set to \&quot;pkcs8\&quot; to have
+        ///     the returned private key contain base64-encoded pkcs8 or PEM-encoded pkcs8 instead. Defaults to \&quot;der\&quot;.
+        /// </value>
+        [JsonPropertyName("private_key_format")]
+        public IssuerPrivateKeyFormat? PrivateKeyFormat { get; set; }
+
+        /// <summary>
+        ///     The requested Subject Alternative Names, if any, in a comma-delimited list. May contain both DNS names and email
+        ///     addresses.
+        /// </summary>
+        /// <value>
+        ///     The requested Subject Alternative Names, if any, in a comma-delimited list. May contain both DNS names and email
+        ///     addresses.
+        /// </value>
+        [JsonPropertyName("alt_names")]
+        public string AltNames { get; set; }
+
+        /// <summary>
+        ///     The requested common name; if you want more than one, specify the alternative names in the alt_names map. If not
+        ///     specified when signing, the common name will be taken from the CSR; other names must still be specified in
+        ///     alt_names or ip_sans.
+        /// </summary>
+        /// <value>
+        ///     The requested common name; if you want more than one, specify the alternative names in the alt_names map. If not
+        ///     specified when signing, the common name will be taken from the CSR; other names must still be specified in
+        ///     alt_names or ip_sans.
+        /// </value>
+        [JsonPropertyName("common_name")]
+        public string CommonName { get; set; }
+
+        /// <summary>
+        ///     If set, Country will be set to this value.
+        /// </summary>
+        /// <value>If set, Country will be set to this value.</value>
+        [JsonPropertyName("country")]
+        public List<string> Country { get; set; }
+
+        /// <summary>
+        ///     If true, the Common Name will not be included in DNS or Email Subject Alternate Names. Defaults to false (CN is
+        ///     included).
+        /// </summary>
+        /// <value>
+        ///     If true, the Common Name will not be included in DNS or Email Subject Alternate Names. Defaults to false (CN is
+        ///     included).
+        /// </value>
+        [JsonPropertyName("exclude_cn_from_sans")]
+        public bool? ExcludeCnFromSans { get; set; }
+
+
+        /// <summary>
+        ///     The requested IP SANs, if any, in a comma-delimited list
+        /// </summary>
+        /// <value>The requested IP SANs, if any, in a comma-delimited list</value>
+        [JsonPropertyName("ip_sans")]
+        public List<string> IpSans { get; set; }
+
+        /// <summary>
+        ///     Provide a name to the generated or existing issuer, the name must be unique across all issuers and not be the
+        ///     reserved value &#x27;default&#x27;
+        /// </summary>
+        /// <value>
+        ///     Provide a name to the generated or existing issuer, the name must be unique across all issuers and not be the
+        ///     reserved value &#x27;default&#x27;
+        /// </value>
+        [JsonPropertyName("issuer_name")]
+        public string IssuerName { get; set; }
+
+        /// <summary>
+        ///     The number of bits to use. Allowed values are 0 (universal default); with rsa key_type: 2048 (default), 3072, or
+        ///     4096; with ec key_type: 224, 256 (default), 384, or 521; ignored with ed25519.
+        /// </summary>
+        /// <value>
+        ///     The number of bits to use. Allowed values are 0 (universal default); with rsa key_type: 2048 (default), 3072, or
+        ///     4096; with ec key_type: 224, 256 (default), 384, or 521; ignored with ed25519.
+        /// </value>
+        [JsonPropertyName("key_bits")]
+        public int? KeyBits { get; set; }
+
+        /// <summary>
+        ///     Provide a name to the generated or existing key, the name must be unique across all keys and not be the reserved
+        ///     value &#x27;default&#x27;
+        /// </summary>
+        /// <value>
+        ///     Provide a name to the generated or existing key, the name must be unique across all keys and not be the reserved
+        ///     value &#x27;default&#x27;
+        /// </value>
+        [JsonPropertyName("key_name")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string KeyName { get; set; }
+
+        /// <summary>
+        ///     Reference to a existing key; either \&quot;default\&quot; for the configured default key, an identifier or the name
+        ///     assigned to the key.
+        /// </summary>
+        /// <value>
+        ///     Reference to a existing key; either \&quot;default\&quot; for the configured default key, an identifier or the
+        ///     name assigned to the key.
+        /// </value>
+        [JsonPropertyName("key_ref")]
+        public string KeyRef { get; set; }
+
+
+        /// <summary>
+        ///     If set, Locality will be set to this value.
+        /// </summary>
+        /// <value>If set, Locality will be set to this value.</value>
+        [JsonPropertyName("locality")]
+        public List<string> Locality { get; set; }
+
+        /// <summary>
+        ///     The name of the managed key to use when the exported type is kms. When kms type is the key type, this field or
+        ///     managed_key_name is required. Ignored for other types.
+        /// </summary>
+        /// <value>
+        ///     The name of the managed key to use when the exported type is kms. When kms type is the key type, this field or
+        ///     managed_key_name is required. Ignored for other types.
+        /// </value>
+        [JsonPropertyName("managed_key_id")]
+        public string ManagedKeyId { get; set; }
+
+        /// <summary>
+        ///     The name of the managed key to use when the exported type is kms. When kms type is the key type, this field or
+        ///     managed_key_id is required. Ignored for other types.
+        /// </summary>
+        /// <value>
+        ///     The name of the managed key to use when the exported type is kms. When kms type is the key type, this field or
+        ///     managed_key_id is required. Ignored for other types.
+        /// </value>
+        [JsonPropertyName("managed_key_name")]
+        public string ManagedKeyName { get; set; }
+
+        /// <summary>
+        ///     The maximum allowable path length
+        /// </summary>
+        /// <value>The maximum allowable path length</value>
+        [JsonPropertyName("max_path_length")]
+        public int? MaxPathLength { get; set; }
+
+        /// <summary>
+        ///     Set the not after field of the certificate with specified date value. The value format should be given in UTC
+        ///     format YYYY-MM-ddTHH:MM:SSZ
+        /// </summary>
+        /// <value>
+        ///     Set the not after field of the certificate with specified date value. The value format should be given in UTC
+        ///     format YYYY-MM-ddTHH:MM:SSZ
+        /// </value>
+        [JsonPropertyName("not_after")]
+        public string NotAfter { get; set; }
+
+        /// <summary>
+        ///     The duration before now which the certificate needs to be backdated by.
+        /// </summary>
+        /// <value>The duration before now which the certificate needs to be backdated by.</value>
+        [JsonPropertyName("not_before_duration")]
+        public string NotBeforeDuration { get; set; }
+
+        /// <summary>
+        ///     If set, O (Organization) will be set to this value.
+        /// </summary>
+        /// <value>If set, O (Organization) will be set to this value.</value>
+        [JsonPropertyName("organization")]
+        public List<string> Organization { get; set; }
+
+        /// <summary>
+        ///     Requested other SANs, in an array with the format &lt;oid&gt;;UTF8:&lt;utf8 string value&gt; for each entry.
+        /// </summary>
+        /// <value>Requested other SANs, in an array with the format &lt;oid&gt;;UTF8:&lt;utf8 string value&gt; for each entry.</value>
+        [JsonPropertyName("other_sans")]
+        public List<string> OtherSans { get; set; }
+
+        /// <summary>
+        ///     If set, OU (OrganizationalUnit) will be set to this value.
+        /// </summary>
+        /// <value>If set, OU (OrganizationalUnit) will be set to this value.</value>
+        [JsonPropertyName("ou")]
+        public List<string> Ou { get; set; }
+
+        /// <summary>
+        ///     Domains for which this certificate is allowed to sign or issue child certificates. If set, all DNS names (subject
+        ///     and alt) on child certs must be exact matches or subsets of the given domains (see
+        ///     https://tools.ietf.org/html/rfc5280#section-4.2.1.10).
+        /// </summary>
+        /// <value>
+        ///     Domains for which this certificate is allowed to sign or issue child certificates. If set, all DNS names
+        ///     (subject and alt) on child certs must be exact matches or subsets of the given domains (see
+        ///     https://tools.ietf.org/html/rfc5280#section-4.2.1.10).
+        /// </value>
+        [JsonPropertyName("permitted_dns_domains")]
+        public List<string> PermittedDnsDomains { get; set; }
+
+        /// <summary>
+        ///     If set, Postal Code will be set to this value.
+        /// </summary>
+        /// <value>If set, Postal Code will be set to this value.</value>
+        [JsonPropertyName("postal_code")]
+        public List<string> PostalCode { get; set; }
+
+
+        /// <summary>
+        ///     If set, Province will be set to this value.
+        /// </summary>
+        /// <value>If set, Province will be set to this value.</value>
+        [JsonPropertyName("province")]
+        public List<string> Province { get; set; }
+
+        /// <summary>
+        ///     The Subject&#x27;s requested serial number, if any. See RFC 4519 Section 2.31 &#x27;serialNumber&#x27; for a
+        ///     description of this field. If you want more than one, specify alternative names in the alt_names map using OID
+        ///     2.5.4.5. This has no impact on the final certificate&#x27;s Serial Number field.
+        /// </summary>
+        /// <value>
+        ///     The Subject&#x27;s requested serial number, if any. See RFC 4519 Section 2.31 &#x27;serialNumber&#x27; for a
+        ///     description of this field. If you want more than one, specify alternative names in the alt_names map using OID
+        ///     2.5.4.5. This has no impact on the final certificate&#x27;s Serial Number field.
+        /// </value>
+        [JsonPropertyName("serial_number")]
+        public string SerialNumber { get; set; }
+
+        /// <summary>
+        ///     The number of bits to use in the signature algorithm; accepts 256 for SHA-2-256, 384 for SHA-2-384, and 512 for
+        ///     SHA-2-512. Defaults to 0 to automatically detect based on key length (SHA-2-256 for RSA keys, and matching the
+        ///     curve size for NIST P-Curves).
+        /// </summary>
+        /// <value>
+        ///     The number of bits to use in the signature algorithm; accepts 256 for SHA-2-256, 384 for SHA-2-384, and 512 for
+        ///     SHA-2-512. Defaults to 0 to automatically detect based on key length (SHA-2-256 for RSA keys, and matching the
+        ///     curve size for NIST P-Curves).
+        /// </value>
+        [JsonPropertyName("signature_bits")]
+        public int? SignatureBits { get; set; }
+
+        /// <summary>
+        ///     If set, Street Address will be set to this value.
+        /// </summary>
+        /// <value>If set, Street Address will be set to this value.</value>
+        [JsonPropertyName("street_address")]
+        public List<string> StreetAddress { get; set; }
+
+        /// <summary>
+        ///     The requested Time To Live for the certificate; sets the expiration date. If not specified the role default,
+        ///     backend default, or system default TTL is used, in that order. Cannot be larger than the mount max TTL. Note: this
+        ///     only has an effect when generating a CA cert or signing a CA cert, not when generating a CSR for an intermediate
+        ///     CA.
+        /// </summary>
+        /// <value>
+        ///     The requested Time To Live for the certificate; sets the expiration date. If not specified the role default,
+        ///     backend default, or system default TTL is used, in that order. Cannot be larger than the mount max TTL. Note: this
+        ///     only has an effect when generating a CA cert or signing a CA cert, not when generating a CSR for an intermediate
+        ///     CA.
+        /// </value>
+        [JsonPropertyName("ttl")]
+        public string Ttl { get; set; }
+
+        /// <summary>
+        ///     The requested URI SANs, if any, in a comma-delimited list.
+        /// </summary>
+        /// <value>The requested URI SANs, if any, in a comma-delimited list.</value>
+        [JsonPropertyName("uri_sans")]
+        public List<string> UriSans { get; set; }
+
+        /// <summary>
+        ///     Whether or not to use PSS signatures when using a RSA key-type issuer. Defaults to false.
+        /// </summary>
+        /// <value>Whether or not to use PSS signatures when using a RSA key-type issuer. Defaults to false.</value>
+        [JsonPropertyName("use_pss")]
+        public bool? UsePss { get; set; }
+    }
+}

--- a/src/VaultSharp/V1/SecretsEngines/PKI/Issuers/IssuerFormat.cs
+++ b/src/VaultSharp/V1/SecretsEngines/PKI/Issuers/IssuerFormat.cs
@@ -1,0 +1,25 @@
+﻿using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
+
+namespace VaultSharp.V1.SecretsEngines.PKI.Issuers
+{
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public enum IssuerFormat
+    {
+        /// <summary>
+        ///     Enum Pem for value: pem
+        /// </summary>
+        [EnumMember(Value = "pem")] pem = 1,
+
+        /// <summary>
+        ///     Enum Der for value: der
+        /// </summary>
+        [EnumMember(Value = "der")] der = 2,
+
+        /// <summary>
+        ///     Enum Pembundle for value: pem_bundle
+        /// </summary>
+        [EnumMember(Value = "pem_bundle")] pem_bundle = 3
+    }
+
+}

--- a/src/VaultSharp/V1/SecretsEngines/PKI/Issuers/IssuerPrivetKeyFormat.cs
+++ b/src/VaultSharp/V1/SecretsEngines/PKI/Issuers/IssuerPrivetKeyFormat.cs
@@ -1,0 +1,29 @@
+﻿using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
+
+namespace VaultSharp.V1.SecretsEngines.PKI.Issuers
+{
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public enum IssuerPrivateKeyFormat
+    {
+        /// <summary>
+        ///     Enum Empty for value: null
+        /// </summary>
+        [EnumMember(Value = null)] Empty = 1,
+
+        /// <summary>
+        ///     Enum Der for value: der
+        /// </summary>
+        [EnumMember(Value = "der")] der = 2,
+
+        /// <summary>
+        ///     Enum Pem for value: pem
+        /// </summary>
+        [EnumMember(Value = "pem")] pem = 3,
+
+        /// <summary>
+        ///     Enum Pkcs8 for value: pkcs8
+        /// </summary>
+        [EnumMember(Value = "pkcs8")] pkcs8 = 4
+    }
+}

--- a/src/VaultSharp/V1/SecretsEngines/PKI/Issuers/IssuerResponseData.cs
+++ b/src/VaultSharp/V1/SecretsEngines/PKI/Issuers/IssuerResponseData.cs
@@ -1,0 +1,31 @@
+﻿using System.Text.Json.Serialization;
+
+namespace VaultSharp.V1.SecretsEngines.PKI.Issuers
+{
+    public class IssuerResponseData
+    {
+        [JsonPropertyName("certificate")]
+        public string Certificate { get; set; }
+
+        [JsonPropertyName("expiration")]
+        public int Expiration { get; set; }
+
+        [JsonPropertyName("issuer_id")]
+        public string IssuerId { get; set; }
+
+        [JsonPropertyName("issuer_name")]
+        public string IssuerName { get; set; }
+
+        [JsonPropertyName("issuing_ca")]
+        public string IssuingCa { get; set; }
+
+        [JsonPropertyName("key_id")]
+        public string KeyId { get; set; }
+
+        [JsonPropertyName("key_name")]
+        public string KeyName { get; set; }
+
+        [JsonPropertyName("serial_number")]
+        public string SerialNumber { get; set; }
+    }
+}

--- a/src/VaultSharp/V1/SecretsEngines/PKI/Issuers/IssuersData.cs
+++ b/src/VaultSharp/V1/SecretsEngines/PKI/Issuers/IssuersData.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace VaultSharp.V1.SecretsEngines.PKI.Issuers
+{
+    public class KeysData
+    {
+        [JsonPropertyName("keys")]
+        public List<string> Keys { get; set; } = new List<string>();
+
+        [JsonPropertyName("key_info")]
+        public Dictionary<string, KeyInfo> KeyInfos { get; set; } = new Dictionary<string, KeyInfo>();
+    }
+
+    public class KeyInfo
+    {
+        [JsonPropertyName("is_default")]
+        public bool IsDefault { get; set; }
+
+        [JsonPropertyName("issuer_name")]
+        public string IssuerName { get; set; } = string.Empty;
+    }
+
+}

--- a/src/VaultSharp/V1/SecretsEngines/PKI/Issuers/PKISecretIssuersProvider.cs
+++ b/src/VaultSharp/V1/SecretsEngines/PKI/Issuers/PKISecretIssuersProvider.cs
@@ -1,0 +1,59 @@
+﻿using System.Net.Http;
+using System.Threading.Tasks;
+using VaultSharp.Core;
+using VaultSharp.V1.Commons;
+
+namespace VaultSharp.V1.SecretsEngines.PKI.Issuers
+{
+    internal class PKISecretIssuersProvider : IPKIIssuers
+    {
+        private readonly Polymath _polymath;
+
+        public PKISecretIssuersProvider(Polymath polymath)
+        {
+            _polymath = polymath;
+        }
+
+        public async Task<Secret<KeysData>> ListIssuers(string pkiBackendMountPoint = null, string wrapTimeToLive = null)
+        {
+            var result = await _polymath.MakeVaultApiRequest<Secret<KeysData>>(pkiBackendMountPoint ?? 
+                _polymath.VaultClientSettings.SecretsEngineMountPoints.PKI, 
+                "/issuers/?list=true", HttpMethod.Get, 
+                null, 
+                wrapTimeToLive: wrapTimeToLive)
+                .ConfigureAwait(_polymath.VaultClientSettings.ContinueAsyncTasksOnCapturedContext);
+            return result;
+        }
+
+        public async Task<Secret<IssuerResponseData>> AddIssuer(IssuerData createIssuerOptions, string pkiBackendMountPoint = null, string wrapTimeToLive = null)
+        {
+            Checker.NotNull(createIssuerOptions, "createIssuerOptions");
+
+            var result = await _polymath.MakeVaultApiRequest<Secret<IssuerResponseData>>(pkiBackendMountPoint ?? _polymath.VaultClientSettings.SecretsEngineMountPoints.PKI, "/root/generate/internal", HttpMethod.Post, createIssuerOptions, wrapTimeToLive: wrapTimeToLive).ConfigureAwait(_polymath.VaultClientSettings.ContinueAsyncTasksOnCapturedContext);
+            return result;
+        }
+
+        public async Task<Secret<IssuerConfigResponseData>> GetIssuerConfigData(string issuerName,
+            string pkiBackendMountPoint = null, string wrapTimeToLive = null)
+        {
+            Checker.NotNull(issuerName, "issuerName");
+            var result = await _polymath.MakeVaultApiRequest<Secret<IssuerConfigResponseData>>(pkiBackendMountPoint ?? _polymath.VaultClientSettings.SecretsEngineMountPoints.PKI, "/issuer/" + issuerName, HttpMethod.Get, null, wrapTimeToLive: wrapTimeToLive).ConfigureAwait(_polymath.VaultClientSettings.ContinueAsyncTasksOnCapturedContext);
+            return result;
+        }
+
+        public async Task<Secret<IssuerConfigResponseData>> ConfigureIssuer(IssuerConfigRequestData data, string pkiBackendMountPoint = null, string wrapTimeToLive = null)
+        {
+            Checker.NotNull(data, "data");
+
+            var result = await _polymath.MakeVaultApiRequest<Secret<IssuerConfigResponseData>>(pkiBackendMountPoint ?? _polymath.VaultClientSettings.SecretsEngineMountPoints.PKI, "/issuer/" + data.IssuerName, HttpMethod.Post, data, wrapTimeToLive: wrapTimeToLive).ConfigureAwait(_polymath.VaultClientSettings.ContinueAsyncTasksOnCapturedContext);
+            return result;
+        }
+
+        public async Task DeleteIssuer(string issuerName, string pkiBackendMountPoint = null,
+            string wrapTimeToLive = null)
+        {
+            Checker.NotNull(issuerName, "issuerName");
+            await _polymath.MakeVaultApiRequest<Secret<IssuerData>>(pkiBackendMountPoint ?? _polymath.VaultClientSettings.SecretsEngineMountPoints.PKI, "/issuer/" + issuerName, HttpMethod.Delete, null, wrapTimeToLive: wrapTimeToLive).ConfigureAwait(_polymath.VaultClientSettings.ContinueAsyncTasksOnCapturedContext);
+        }
+    }
+}

--- a/src/VaultSharp/V1/SecretsEngines/PKI/KeyUsageConstants.cs
+++ b/src/VaultSharp/V1/SecretsEngines/PKI/KeyUsageConstants.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+
+namespace VaultSharp.V1.SecretsEngines.PKI
+{
+    public class KeyUsageConstants
+    {
+        public const string DigitalSignature = "DigitalSignature";
+        public const string ContentCommitment = "ContentCommitment";
+        public const string KeyEncipherment = "KeyEncipherment";
+        public const string DataEncipherment = "DataEncipherment";
+        public const string KeyAgreement = "KeyAgreement";
+        public const string CertSign = "CertSign";
+        public const string CRLSign = "CRLSign";
+        public const string EncipherOnly = "EncipherOnly";
+        public const string DecipherOnly = "DecipherOnly";
+
+        public static IReadOnlyList<string> DefaultSSLKeyUsages = new List<string>()
+        {
+            DigitalSignature,
+            KeyEncipherment,
+            KeyAgreement
+        };
+    }
+}

--- a/src/VaultSharp/V1/SecretsEngines/PKI/Keys/IPKIKeys.cs
+++ b/src/VaultSharp/V1/SecretsEngines/PKI/Keys/IPKIKeys.cs
@@ -1,0 +1,21 @@
+﻿using System.Threading.Tasks;
+using VaultSharp.V1.Commons;
+
+namespace VaultSharp.V1.SecretsEngines.PKI.Keys
+{
+    public interface IPKIKeys
+    {
+        Task<Secret<KeysData>> ListKeys(string pkiBackendMountPoint = null, string wrapTimeToLive = null);
+
+
+        Task<Secret<KeyData>> GenerateKey(KeyData data, string pkiBackendMountPoint = null, string wrapTimeToLive = null);
+
+        Task<Secret<KeyData>> GetKey(string keyName, string pkiBackendMountPoint = null, string wrapTimeToLive = null);
+
+        Task<Secret<ImportKeyData>> ImportKey(ImportKeyData data, string pkiBackendMountPoint = null,
+            string wrapTimeToLive = null);
+
+
+        Task DeleteKey(string keyName, string pkiBackendMountPoint = null, string wrapTimeToLive = null);
+    }
+}

--- a/src/VaultSharp/V1/SecretsEngines/PKI/Keys/ImportKeyData.cs
+++ b/src/VaultSharp/V1/SecretsEngines/PKI/Keys/ImportKeyData.cs
@@ -1,0 +1,17 @@
+﻿using System.Text.Json.Serialization;
+
+namespace VaultSharp.V1.SecretsEngines.PKI.Keys
+{
+    public class ImportKeyData
+    {
+        /// <summary>
+        /// Optional name to be used for this key
+        /// </summary>
+        /// <value>Optional name to be used for this key</value>
+        [JsonPropertyName("key_name")]
+        public string KeyName { get; set; }
+
+        [JsonPropertyName("pem_bundle")]
+        public string PemBundle { get; set; }
+    }
+}

--- a/src/VaultSharp/V1/SecretsEngines/PKI/Keys/KeyData.cs
+++ b/src/VaultSharp/V1/SecretsEngines/PKI/Keys/KeyData.cs
@@ -1,0 +1,57 @@
+﻿using System.Text.Json.Serialization;
+
+namespace VaultSharp.V1.SecretsEngines.PKI.Keys
+{
+    public class KeyData
+    {
+        public KeyData()
+        {
+            this.KeyType = PrivateKeyType.rsa;
+
+        }
+
+        /// <summary>
+        /// The type of key generation. 
+        /// </summary>
+        [JsonIgnore]
+        public KeyGenerationType KeyGenerationType { get; set; }
+
+        /// <summary>
+        /// The type of key to use; defaults to RSA. \&quot;rsa\&quot; \&quot;ec\&quot; and \&quot;ed25519\&quot; are the only valid values.
+        /// </summary>
+        /// <value>The type of key to use; defaults to RSA. \&quot;rsa\&quot; \&quot;ec\&quot; and \&quot;ed25519\&quot; are the only valid values.</value>
+        [JsonPropertyName("key_type")]
+        public PrivateKeyType KeyType { get; set; }
+
+        /// <summary>
+        /// The number of bits to use. Allowed values are 0 (universal default); with rsa key_type: 2048 (default), 3072, or 4096; with ec key_type: 224, 256 (default), 384, or 521; ignored with ed25519.
+        /// </summary>
+        /// <value>The number of bits to use. Allowed values are 0 (universal default); with rsa key_type: 2048 (default), 3072, or 4096; with ec key_type: 224, 256 (default), 384, or 521; ignored with ed25519.</value>
+        [JsonPropertyName("key_bits")]
+        public int KeyBits { get; set; }
+
+        /// <summary>
+        /// Optional name to be used for this key
+        /// </summary>
+        /// <value>Optional name to be used for this key</value>
+        [JsonPropertyName("key_name")]
+        public string KeyName { get; set; }
+
+        /// <summary>
+        /// The name of the managed key to use when the exported type is kms. When kms type is the key type, this field or managed_key_name is required. Ignored for other types.
+        /// </summary>
+        /// <value>The name of the managed key to use when the exported type is kms. When kms type is the key type, this field or managed_key_name is required. Ignored for other types.</value>
+        [JsonPropertyName("managed_key_id")]
+        public string ManagedKeyId { get; set; }
+
+        /// <summary>
+        /// The name of the managed key to use when the exported type is kms. When kms type is the key type, this field or managed_key_id is required. Ignored for other types.
+        /// </summary>
+        /// <value>The name of the managed key to use when the exported type is kms. When kms type is the key type, this field or managed_key_id is required. Ignored for other types.</value>
+        [JsonPropertyName("managed_key_name")]
+        public string ManagedKeyName { get; set; }
+
+        [JsonPropertyName("private_key")]
+        public string PrivateKey { get; set; }
+    }
+}

--- a/src/VaultSharp/V1/SecretsEngines/PKI/Keys/KeyGenerationType.cs
+++ b/src/VaultSharp/V1/SecretsEngines/PKI/Keys/KeyGenerationType.cs
@@ -1,0 +1,8 @@
+﻿namespace VaultSharp.V1.SecretsEngines.PKI.Keys
+{
+    public enum KeyGenerationType
+    {
+        Internal,
+        External
+    }
+}

--- a/src/VaultSharp/V1/SecretsEngines/PKI/Keys/KeysData.cs
+++ b/src/VaultSharp/V1/SecretsEngines/PKI/Keys/KeysData.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace VaultSharp.V1.SecretsEngines.PKI.Keys
+{
+    public class KeysData
+    {
+        [JsonPropertyName("keys")]
+        public List<string> Keys { get; set; } = new List<string>();
+
+        [JsonPropertyName("key_info")]
+        public Dictionary<string, KeyInfo> KeyInfos { get; set; } = new Dictionary<string, KeyInfo>();
+    }
+
+    public class KeyInfo
+    {
+        [JsonPropertyName("is_default")]
+        public bool IsDefault { get; set; }
+
+        [JsonPropertyName("key_name")]
+        public string KeyName { get; set; } = string.Empty;
+    }
+
+}

--- a/src/VaultSharp/V1/SecretsEngines/PKI/Keys/PKISecretKeysProvider.cs
+++ b/src/VaultSharp/V1/SecretsEngines/PKI/Keys/PKISecretKeysProvider.cs
@@ -1,0 +1,70 @@
+﻿using System.Net.Http;
+using System.Threading.Tasks;
+using VaultSharp.Core;
+using VaultSharp.V1.Commons;
+
+namespace VaultSharp.V1.SecretsEngines.PKI.Keys
+{
+    internal class PKISecretKeysProvider : IPKIKeys
+    {
+        private readonly Polymath _polymath;
+        const string InternalPath = "keys/generate/internal";
+        const string ExternalPath = "keys/generate/exported";
+
+        public PKISecretKeysProvider(Polymath polymath)
+        {
+            _polymath = polymath;
+        }
+
+        public async Task<Secret<KeysData>> ListKeys(string pkiBackendMountPoint = null, string wrapTimeToLive = null)
+        {
+            var result = await _polymath.MakeVaultApiRequest<Secret<KeysData>>(pkiBackendMountPoint ?? 
+                                                                               _polymath.VaultClientSettings.SecretsEngineMountPoints.PKI, 
+                    "/keys/?list=true", HttpMethod.Get, 
+                    null, 
+                    wrapTimeToLive: wrapTimeToLive)
+                .ConfigureAwait(_polymath.VaultClientSettings.ContinueAsyncTasksOnCapturedContext);
+            return result;
+        }
+
+        public async Task<Secret<KeyData>> GenerateKey(KeyData data, string pkiBackendMountPoint = null, string wrapTimeToLive = null)
+        {
+            Checker.NotNull(data, "data");
+
+            var generationPath = data.KeyGenerationType == KeyGenerationType.Internal ? InternalPath : ExternalPath;
+
+            var result = await _polymath.MakeVaultApiRequest<Secret<KeyData>>(pkiBackendMountPoint ?? _polymath.VaultClientSettings.SecretsEngineMountPoints.PKI, generationPath, HttpMethod.Post, data, wrapTimeToLive: wrapTimeToLive)
+                .ConfigureAwait(_polymath.VaultClientSettings.ContinueAsyncTasksOnCapturedContext);
+            result.Data.KeyGenerationType = data.KeyGenerationType;
+            return result;
+        }
+
+        public async Task<Secret<KeyData>> GetKey(string keyName, string pkiBackendMountPoint = null, string wrapTimeToLive = null)
+        {
+            Checker.NotNull(keyName, "keyName");
+            var result = await _polymath.MakeVaultApiRequest<Secret<KeyData>>(
+                    pkiBackendMountPoint ?? _polymath.VaultClientSettings.SecretsEngineMountPoints.PKI,
+                    "/key/" + keyName, HttpMethod.Get, null, wrapTimeToLive: wrapTimeToLive)
+                .ConfigureAwait(_polymath.VaultClientSettings.ContinueAsyncTasksOnCapturedContext);
+            return result;
+        }
+
+        public async Task<Secret<ImportKeyData>> ImportKey(ImportKeyData data, string pkiBackendMountPoint = null, string wrapTimeToLive = null)
+        {
+            Checker.NotNull(data, "data");
+
+            var importPath = "keys/import";
+
+            var result = await _polymath.MakeVaultApiRequest<Secret<ImportKeyData>>(pkiBackendMountPoint ?? _polymath.VaultClientSettings.SecretsEngineMountPoints.PKI, importPath, HttpMethod.Post, data, wrapTimeToLive: wrapTimeToLive)
+                .ConfigureAwait(_polymath.VaultClientSettings.ContinueAsyncTasksOnCapturedContext);
+            return result;
+        }
+
+        public async Task DeleteKey(string keyName, string pkiBackendMountPoint = null, string wrapTimeToLive = null)
+        {
+            Checker.NotNull(keyName, "keyName");
+            await _polymath.MakeVaultApiRequest<Secret<KeysData>>(pkiBackendMountPoint ?? _polymath.VaultClientSettings.SecretsEngineMountPoints.PKI, "/key/" + keyName, HttpMethod.Delete, null, wrapTimeToLive: wrapTimeToLive)
+                .ConfigureAwait(_polymath.VaultClientSettings.ContinueAsyncTasksOnCapturedContext);
+        }
+    }
+}

--- a/src/VaultSharp/V1/SecretsEngines/PKI/PKISecretsEngineProvider.cs
+++ b/src/VaultSharp/V1/SecretsEngines/PKI/PKISecretsEngineProvider.cs
@@ -4,6 +4,9 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using VaultSharp.Core;
 using VaultSharp.V1.Commons;
+using VaultSharp.V1.SecretsEngines.PKI.Issuers;
+using VaultSharp.V1.SecretsEngines.PKI.Keys;
+using VaultSharp.V1.SecretsEngines.PKI.Roles;
 
 namespace VaultSharp.V1.SecretsEngines.PKI
 {
@@ -14,7 +17,16 @@ namespace VaultSharp.V1.SecretsEngines.PKI
         public PKISecretsEngineProvider(Polymath polymath)
         {
             _polymath = polymath;
+            this.Issuers = new PKISecretIssuersProvider(polymath);
+            this.Keys = new PKISecretKeysProvider(polymath);
+            this.Roles = new PKISecretRolesProvider(polymath);
         }
+
+        public IPKIIssuers Issuers { get; }
+
+        public IPKIKeys Keys { get; }
+
+        public IPKIRoles Roles { get; }
 
         public async Task<Secret<CertificateCredentials>> GetCredentialsAsync(string pkiRoleName, CertificateCredentialsRequestOptions certificateCredentialRequestOptions, string pkiBackendMountPoint = null, string wrapTimeToLive = null)
         {

--- a/src/VaultSharp/V1/SecretsEngines/PKI/PrivateKeyType.cs
+++ b/src/VaultSharp/V1/SecretsEngines/PKI/PrivateKeyType.cs
@@ -1,0 +1,24 @@
+﻿using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
+
+namespace VaultSharp.V1.SecretsEngines.PKI
+{
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public enum PrivateKeyType
+    {
+        /// <summary>
+        ///     Enum Rsa for value: rsa
+        /// </summary>
+        [EnumMember(Value = "rsa")] rsa = 1,
+
+        /// <summary>
+        ///     Enum Ec for value: ec
+        /// </summary>
+        [EnumMember(Value = "ec")] ec = 2,
+
+        /// <summary>
+        ///     Enum Ed25519 for value: ed25519
+        /// </summary>
+        [EnumMember(Value = "ed25519")] ed25519 = 3,
+    }
+}

--- a/src/VaultSharp/V1/SecretsEngines/PKI/Roles/IPKIRoles.cs
+++ b/src/VaultSharp/V1/SecretsEngines/PKI/Roles/IPKIRoles.cs
@@ -1,0 +1,17 @@
+﻿using System.Threading.Tasks;
+using VaultSharp.V1.Commons;
+using VaultSharp.V1.SecretsEngines.PKI.Issuers;
+
+namespace VaultSharp.V1.SecretsEngines.PKI.Roles
+{
+    public interface IPKIRoles
+    {
+        Task<Secret<RolesData>> ListRoles(string pkiBackendMountPoint = null, string wrapTimeToLive = null);
+
+        Task<Secret<RoleData>> AddRole(RoleData data, string pkiBackendMountPoint = null, string wrapTimeToLive = null);
+
+        Task<Secret<RoleData>> GetRole(string roleName, string pkiBackendMountPoint = null, string wrapTimeToLive = null);
+
+        Task DeleteRole(string roleName, string pkiBackendMountPoint = null);
+    }
+}

--- a/src/VaultSharp/V1/SecretsEngines/PKI/Roles/PKISecretRolesProvider.cs
+++ b/src/VaultSharp/V1/SecretsEngines/PKI/Roles/PKISecretRolesProvider.cs
@@ -1,0 +1,47 @@
+﻿using System.Net.Http;
+using System.Threading.Tasks;
+using VaultSharp.Core;
+using VaultSharp.V1.Commons;
+
+namespace VaultSharp.V1.SecretsEngines.PKI.Roles
+{
+    internal class PKISecretRolesProvider : IPKIRoles
+    {
+        private readonly Polymath _polymath;
+
+        public PKISecretRolesProvider(Polymath polymath)
+        {
+            _polymath = polymath;
+        }
+
+        public async Task<Secret<RolesData>> ListRoles(string pkiBackendMountPoint = null, string wrapTimeToLive = null)
+        {
+            var result = await _polymath.MakeVaultApiRequest<Secret<RolesData>>(pkiBackendMountPoint ?? _polymath.VaultClientSettings.SecretsEngineMountPoints.PKI,
+                    "/roles/?list=true", HttpMethod.Get,
+                    wrapTimeToLive: wrapTimeToLive)
+                .ConfigureAwait(_polymath.VaultClientSettings.ContinueAsyncTasksOnCapturedContext);
+            return result;
+        }
+
+        public async Task<Secret<RoleData>> AddRole(RoleData data, string pkiBackendMountPoint = null, string wrapTimeToLive = null)
+        {
+            Checker.NotNull(data, "data");
+            var result = await _polymath.MakeVaultApiRequest<Secret<RoleData>>(pkiBackendMountPoint ?? _polymath.VaultClientSettings.SecretsEngineMountPoints.PKI, "/roles/" + data.Name, HttpMethod.Post, data, wrapTimeToLive: wrapTimeToLive).ConfigureAwait(_polymath.VaultClientSettings.ContinueAsyncTasksOnCapturedContext);
+            return result;
+        }
+
+        public async Task<Secret<RoleData>> GetRole(string roleName, string pkiBackendMountPoint = null, string wrapTimeToLive = null)
+        {
+            Checker.NotNull(roleName, "roleName");
+            var result = await _polymath.MakeVaultApiRequest<Secret<RoleData>>(pkiBackendMountPoint ?? _polymath.VaultClientSettings.SecretsEngineMountPoints.PKI, "/roles/" + roleName, HttpMethod.Get, null, wrapTimeToLive:wrapTimeToLive).ConfigureAwait(_polymath.VaultClientSettings.ContinueAsyncTasksOnCapturedContext);
+            result.Data.Name = roleName;
+            return result;
+        }
+
+        public async Task DeleteRole(string roleName, string pkiBackendMountPoint = null)
+        {
+            Checker.NotNull(roleName, "roleName");
+            await _polymath.MakeVaultApiRequest(pkiBackendMountPoint ?? _polymath.VaultClientSettings.SecretsEngineMountPoints.PKI, "/roles/" + roleName, HttpMethod.Delete).ConfigureAwait(_polymath.VaultClientSettings.ContinueAsyncTasksOnCapturedContext);
+        }
+    }
+}

--- a/src/VaultSharp/V1/SecretsEngines/PKI/Roles/PrivateKeyRoleType.cs
+++ b/src/VaultSharp/V1/SecretsEngines/PKI/Roles/PrivateKeyRoleType.cs
@@ -1,0 +1,30 @@
+﻿using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
+
+namespace VaultSharp.V1.SecretsEngines.PKI.Roles
+{
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public enum PrivateKeyRoleType
+    {
+        /// <summary>
+        ///     Enum Rsa for value: rsa
+        /// </summary>
+        [EnumMember(Value = "rsa")] rsa = 1,
+
+        /// <summary>
+        ///     Enum Ec for value: ec
+        /// </summary>
+        [EnumMember(Value = "ec")] ec = 2,
+
+        /// <summary>
+        ///     Enum Ed25519 for value: ed25519
+        /// </summary>
+        [EnumMember(Value = "ed25519")] ed25519 = 3,
+
+        /// <summary>
+        /// Enum Any for value: any
+        /// </summary>
+        [EnumMember(Value = "any")]
+        any = 4
+    }
+}

--- a/src/VaultSharp/V1/SecretsEngines/PKI/Roles/RoleData.cs
+++ b/src/VaultSharp/V1/SecretsEngines/PKI/Roles/RoleData.cs
@@ -1,0 +1,357 @@
+﻿using System.Collections.Generic;
+using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
+using System.Xml.Linq;
+
+namespace VaultSharp.V1.SecretsEngines.PKI.Roles
+{
+    public class RoleData
+    {
+        public RoleData()
+        {
+            this.IssuerRef = @"default";
+            this.NotBeforeDuration = 30;
+            this.AllowIpSans = true;
+            this.AllowLocalhost = true;
+            this.AllowWildcardCertificates = true;
+            this.AllowedUriSansTemplate = false;
+            this.KeyType = PrivateKeyRoleType.rsa;
+            this.RequireCn = true;
+            this.UseCsrCommonName = true;
+            this.UseCsrSans = true;
+            this.UsePss = false;
+        }
+
+        [JsonIgnore]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The type of key to use; defaults to RSA. \&quot;rsa\&quot; \&quot;ec\&quot;, \&quot;ed25519\&quot; and \&quot;any\&quot; are the only valid values.
+        /// </summary>
+        /// <value>The type of key to use; defaults to RSA. \&quot;rsa\&quot; \&quot;ec\&quot;, \&quot;ed25519\&quot; and \&quot;any\&quot; are the only valid values.</value>
+        [JsonPropertyName("key_type")]
+        public PrivateKeyRoleType KeyType { get; set; }
+
+        /// <summary>
+        /// If set, clients can request certificates for any domain, regardless of allowed_domains restrictions. See the documentation for more information.
+        /// </summary>
+        /// <value>If set, clients can request certificates for any domain, regardless of allowed_domains restrictions. See the documentation for more information.</value>
+        [JsonPropertyName("allow_any_name")]
+        public bool AllowAnyName { get; set; }
+
+        /// <summary>
+        /// If set, clients can request certificates for the base domains themselves, e.g. \&quot;example.com\&quot; of domains listed in allowed_domains. This is a separate option as in some cases this can be considered a security threat. See the documentation for more information.
+        /// </summary>
+        /// <value>If set, clients can request certificates for the base domains themselves, e.g. \&quot;example.com\&quot; of domains listed in allowed_domains. This is a separate option as in some cases this can be considered a security threat. See the documentation for more information.</value>
+        [JsonPropertyName("allow_bare_domains")]
+        public bool AllowBareDomains { get; set; }
+
+        /// <summary>
+        /// If set, domains specified in allowed_domains can include shell-style glob patterns, e.g. \&quot;ftp*.example.com\&quot;. See the documentation for more information.
+        /// </summary>
+        /// <value>If set, domains specified in allowed_domains can include shell-style glob patterns, e.g. \&quot;ftp*.example.com\&quot;. See the documentation for more information.</value>
+        [JsonPropertyName("allow_glob_domains")]
+        public bool AllowGlobDomains { get; set; }
+
+        /// <summary>
+        /// If set, IP Subject Alternative Names are allowed. Any valid IP is accepted and No authorization checking is performed.
+        /// </summary>
+        /// <value>If set, IP Subject Alternative Names are allowed. Any valid IP is accepted and No authorization checking is performed.</value>
+        [JsonPropertyName("allow_ip_sans")]
+        public bool AllowIpSans { get; set; }
+
+        /// <summary>
+        /// Whether to allow \&quot;localhost\&quot; and \&quot;localdomain\&quot; as a valid common name in a request, independent of allowed_domains value.
+        /// </summary>
+        /// <value>Whether to allow \&quot;localhost\&quot; and \&quot;localdomain\&quot; as a valid common name in a request, independent of allowed_domains value.</value>
+        [JsonPropertyName("allow_localhost")]
+        public bool AllowLocalhost { get; set; }
+
+        /// <summary>
+        /// If set, clients can request certificates for subdomains of domains listed in allowed_domains, including wildcard subdomains. See the documentation for more information.
+        /// </summary>
+        /// <value>If set, clients can request certificates for subdomains of domains listed in allowed_domains, including wildcard subdomains. See the documentation for more information.</value>
+        [JsonPropertyName("allow_subdomains")]
+        public bool AllowSubdomains { get; set; }
+
+        /// <summary>
+        /// If set, allows certificates with wildcards in the common name to be issued, conforming to RFC 6125&#39;s Section 6.4.3; e.g., \&quot;*.example.net\&quot; or \&quot;b*z.example.net\&quot;. See the documentation for more information.
+        /// </summary>
+        /// <value>If set, allows certificates with wildcards in the common name to be issued, conforming to RFC 6125&#39;s Section 6.4.3; e.g., \&quot;*.example.net\&quot; or \&quot;b*z.example.net\&quot;. See the documentation for more information.</value>
+        [JsonPropertyName("allow_wildcard_certificates")]
+        public bool AllowWildcardCertificates { get; set; }
+
+        /// <summary>
+        /// Specifies the domains this role is allowed to issue certificates for. This is used with the allow_bare_domains, allow_subdomains, and allow_glob_domains to determine matches for the common name, DNS-typed SAN entries, and Email-typed SAN entries of certificates. See the documentation for more information. This parameter accepts a comma-separated string or list of domains.
+        /// </summary>
+        /// <value>Specifies the domains this role is allowed to issue certificates for. This is used with the allow_bare_domains, allow_subdomains, and allow_glob_domains to determine matches for the common name, DNS-typed SAN entries, and Email-typed SAN entries of certificates. See the documentation for more information. This parameter accepts a comma-separated string or list of domains.</value>
+        [JsonPropertyName("allowed_domains")]
+        public List<string> AllowedDomains { get; set; }
+
+        /// <summary>
+        /// If set, Allowed domains can be specified using identity template policies. Non-templated domains are also permitted.
+        /// </summary>
+        /// <value>If set, Allowed domains can be specified using identity template policies. Non-templated domains are also permitted.</value>
+        [JsonPropertyName("allowed_domains_template")]
+        public bool AllowedDomainsTemplate { get; set; }
+
+        /// <summary>
+        /// If set, an array of allowed other names to put in SANs. These values support globbing and must be in the format &lt;oid&gt;;&lt;type&gt;:&lt;value&gt;. Currently only \&quot;utf8\&quot; is a valid type. All values, including globbing values, must use this syntax, with the exception being a single \&quot;*\&quot; which allows any OID and any value (but type must still be utf8).
+        /// </summary>
+        /// <value>If set, an array of allowed other names to put in SANs. These values support globbing and must be in the format &lt;oid&gt;;&lt;type&gt;:&lt;value&gt;. Currently only \&quot;utf8\&quot; is a valid type. All values, including globbing values, must use this syntax, with the exception being a single \&quot;*\&quot; which allows any OID and any value (but type must still be utf8).</value>
+        [JsonPropertyName("allowed_other_sans")]
+        public List<string> AllowedOtherSans { get; set; }
+
+        /// <summary>
+        /// If set, an array of allowed serial numbers to put in Subject. These values support globbing.
+        /// </summary>
+        /// <value>If set, an array of allowed serial numbers to put in Subject. These values support globbing.</value>
+        [JsonPropertyName("allowed_serial_numbers")]
+        public List<string> AllowedSerialNumbers { get; set; }
+
+        /// <summary>
+        /// If set, an array of allowed URIs for URI Subject Alternative Names. Any valid URI is accepted, these values support globbing.
+        /// </summary>
+        /// <value>If set, an array of allowed URIs for URI Subject Alternative Names. Any valid URI is accepted, these values support globbing.</value>
+        [JsonPropertyName("allowed_uri_sans")]
+        public List<string> AllowedUriSans { get; set; }
+
+        /// <summary>
+        /// If set, Allowed URI SANs can be specified using identity template policies. Non-templated URI SANs are also permitted.
+        /// </summary>
+        /// <value>If set, Allowed URI SANs can be specified using identity template policies. Non-templated URI SANs are also permitted.</value>
+        [JsonPropertyName("allowed_uri_sans_template")]
+        public bool AllowedUriSansTemplate { get; set; }
+
+        /// <summary>
+        /// If set, an array of allowed user-ids to put in user system login name specified here: https://www.rfc-editor.org/rfc/rfc1274#section-9.3.1
+        /// </summary>
+        /// <value>If set, an array of allowed user-ids to put in user system login name specified here: https://www.rfc-editor.org/rfc/rfc1274#section-9.3.1</value>
+        [JsonPropertyName("allowed_user_ids")]
+        public List<string> AllowedUserIds { get; set; }
+
+        /// <summary>
+        /// Backend Type
+        /// </summary>
+        /// <value>Backend Type</value>
+        [JsonPropertyName("backend")]
+        public string Backend { get; set; }
+
+        /// <summary>
+        /// Mark Basic Constraints valid when issuing non-CA certificates.
+        /// </summary>
+        /// <value>Mark Basic Constraints valid when issuing non-CA certificates.</value>
+        [JsonPropertyName("basic_constraints_valid_for_non_ca")]
+        public bool BasicConstraintsValidForNonCa { get; set; }
+
+        /// <summary>
+        /// If set, certificates are flagged for client auth use. Defaults to true. See also RFC 5280 Section 4.2.1.12.
+        /// </summary>
+        /// <value>If set, certificates are flagged for client auth use. Defaults to true. See also RFC 5280 Section 4.2.1.12.</value>
+        [JsonPropertyName("client_flag")]
+        public bool ClientFlag { get; set; }
+
+        /// <summary>
+        /// List of allowed validations to run against the Common Name field. Values can include &#39;email&#39; to validate the CN is a email address, &#39;hostname&#39; to validate the CN is a valid hostname (potentially including wildcards). When multiple validations are specified, these take OR semantics (either email OR hostname are allowed). The special value &#39;disabled&#39; allows disabling all CN name validations, allowing for arbitrary non-Hostname, non-Email address CNs.
+        /// </summary>
+        /// <value>List of allowed validations to run against the Common Name field. Values can include &#39;email&#39; to validate the CN is a email address, &#39;hostname&#39; to validate the CN is a valid hostname (potentially including wildcards). When multiple validations are specified, these take OR semantics (either email OR hostname are allowed). The special value &#39;disabled&#39; allows disabling all CN name validations, allowing for arbitrary non-Hostname, non-Email address CNs.</value>
+        [JsonPropertyName("cn_validations")]
+        public List<string> CnValidations { get; set; }
+
+        /// <summary>
+        /// If set, certificates are flagged for code signing use. Defaults to false. See also RFC 5280 Section 4.2.1.12.
+        /// </summary>
+        /// <value>If set, certificates are flagged for code signing use. Defaults to false. See also RFC 5280 Section 4.2.1.12.</value>
+        [JsonPropertyName("code_signing_flag")]
+        public bool CodeSigningFlag { get; set; }
+
+        /// <summary>
+        /// If set, Country will be set to this value in certificates issued by this role.
+        /// </summary>
+        /// <value>If set, Country will be set to this value in certificates issued by this role.</value>
+        [JsonPropertyName("country")]
+        public List<string> Country { get; set; }
+
+        /// <summary>
+        /// If set, certificates are flagged for email protection use. Defaults to false. See also RFC 5280 Section 4.2.1.12.
+        /// </summary>
+        /// <value>If set, certificates are flagged for email protection use. Defaults to false. See also RFC 5280 Section 4.2.1.12.</value>
+        [JsonPropertyName("email_protection_flag")]
+        public bool EmailProtectionFlag { get; set; }
+
+        /// <summary>
+        /// If set, only valid host names are allowed for CN and DNS SANs, and the host part of email addresses. Defaults to true.
+        /// </summary>
+        /// <value>If set, only valid host names are allowed for CN and DNS SANs, and the host part of email addresses. Defaults to true.</value>
+        [JsonPropertyName("enforce_hostnames")]
+        public bool EnforceHostnames { get; set; }
+
+        /// <summary>
+        /// A comma-separated string or list of extended key usages. Valid values can be found at https://golang.org/pkg/crypto/x509/#ExtKeyUsage - - simply drop the \&quot;ExtKeyUsage\&quot; part of the name. To remove all key usages from being set, set this value to an empty list. See also RFC 5280 Section 4.2.1.12.
+        /// </summary>
+        /// <value>A comma-separated string or list of extended key usages. Valid values can be found at https://golang.org/pkg/crypto/x509/#ExtKeyUsage - - simply drop the \&quot;ExtKeyUsage\&quot; part of the name. To remove all key usages from being set, set this value to an empty list. See also RFC 5280 Section 4.2.1.12.</value>
+        [JsonPropertyName("ext_key_usage")]
+        public List<string> ExtKeyUsage { get; set; }
+
+        /// <summary>
+        /// A comma-separated string or list of extended key usage oids.
+        /// </summary>
+        /// <value>A comma-separated string or list of extended key usage oids.</value>
+        [JsonPropertyName("ext_key_usage_oids")]
+        public List<string> ExtKeyUsageOids { get; set; }
+
+        /// <summary>
+        /// If set, certificates issued/signed against this role will have Vault leases attached to them. Defaults to \&quot;false\&quot;. Certificates can be added to the CRL by \&quot;vault revoke &lt;lease_id&gt;\&quot; when certificates are associated with leases. It can also be done using the \&quot;pki/revoke\&quot; endpoint. However, when lease generation is disabled, invoking \&quot;pki/revoke\&quot; would be the only way to add the certificates to the CRL. When large number of certificates are generated with long lifetimes, it is recommended that lease generation be disabled, as large amount of leases adversely affect the startup time of Vault.
+        /// </summary>
+        /// <value>If set, certificates issued/signed against this role will have Vault leases attached to them. Defaults to \&quot;false\&quot;. Certificates can be added to the CRL by \&quot;vault revoke &lt;lease_id&gt;\&quot; when certificates are associated with leases. It can also be done using the \&quot;pki/revoke\&quot; endpoint. However, when lease generation is disabled, invoking \&quot;pki/revoke\&quot; would be the only way to add the certificates to the CRL. When large number of certificates are generated with long lifetimes, it is recommended that lease generation be disabled, as large amount of leases adversely affect the startup time of Vault.</value>
+        [JsonPropertyName("generate_lease")]
+        public bool GenerateLease { get; set; }
+
+        /// <summary>
+        /// Reference to the issuer used to sign requests serviced by this role.
+        /// </summary>
+        /// <value>Reference to the issuer used to sign requests serviced by this role.</value>
+        [JsonPropertyName("issuer_ref")]
+        public string IssuerRef { get; set; }
+
+        /// <summary>
+        /// The number of bits to use. Allowed values are 0 (universal default); with rsa key_type: 2048 (default), 3072, or 4096; with ec key_type: 224, 256 (default), 384, or 521; ignored with ed25519.
+        /// </summary>
+        /// <value>The number of bits to use. Allowed values are 0 (universal default); with rsa key_type: 2048 (default), 3072, or 4096; with ec key_type: 224, 256 (default), 384, or 521; ignored with ed25519.</value>
+        [JsonPropertyName("key_bits")]
+        public int KeyBits { get; set; }
+
+        /// <summary>
+        /// A comma-separated string or list of key usages (not extended key usages). Valid values can be found at https://golang.org/pkg/crypto/x509/#KeyUsage - - simply drop the \&quot;KeyUsage\&quot; part of the name. To remove all key usages from being set, set this value to an empty list. See also RFC 5280 Section 4.2.1.3.
+        /// </summary>
+        /// <value>A comma-separated string or list of key usages (not extended key usages). Valid values can be found at https://golang.org/pkg/crypto/x509/#KeyUsage - - simply drop the \&quot;KeyUsage\&quot; part of the name. To remove all key usages from being set, set this value to an empty list. See also RFC 5280 Section 4.2.1.3.</value>
+        [JsonPropertyName("key_usage")]
+        public List<string> KeyUsage { get; set; }
+
+        /// <summary>
+        /// If set, Locality will be set to this value in certificates issued by this role.
+        /// </summary>
+        /// <value>If set, Locality will be set to this value in certificates issued by this role.</value>
+        [JsonPropertyName("locality")]
+        public List<string> Locality { get; set; }
+
+        /// <summary>
+        /// The maximum allowed lease duration. If not set, defaults to the system maximum lease TTL.
+        /// </summary>
+        /// <value>The maximum allowed lease duration. If not set, defaults to the system maximum lease TTL.</value>
+        [JsonPropertyName("max_ttl")]
+        public long MaxTtl { get; set; }
+
+        /// <summary>
+        /// If set, certificates issued/signed against this role will not be stored in the storage backend. This can improve performance when issuing large numbers of certificates. However, certificates issued in this way cannot be enumerated or revoked, so this option is recommended only for certificates that are non-sensitive, or extremely short-lived. This option implies a value of \&quot;false\&quot; for \&quot;generate_lease\&quot;.
+        /// </summary>
+        /// <value>If set, certificates issued/signed against this role will not be stored in the storage backend. This can improve performance when issuing large numbers of certificates. However, certificates issued in this way cannot be enumerated or revoked, so this option is recommended only for certificates that are non-sensitive, or extremely short-lived. This option implies a value of \&quot;false\&quot; for \&quot;generate_lease\&quot;.</value>
+        [JsonPropertyName("no_store")]
+        public bool NoStore { get; set; }
+
+        /// <summary>
+        /// Set the not after field of the certificate with specified date value. The value format should be given in UTC format YYYY-MM-ddTHH:MM:SSZ.
+        /// </summary>
+        /// <value>Set the not after field of the certificate with specified date value. The value format should be given in UTC format YYYY-MM-ddTHH:MM:SSZ.</value>
+        [JsonPropertyName("not_after")]
+        public string NotAfter { get; set; }
+
+        /// <summary>
+        /// The duration before now which the certificate needs to be backdated by.
+        /// </summary>
+        /// <value>The duration before now which the certificate needs to be backdated by.</value>
+        [JsonPropertyName("not_before_duration")]
+        public long NotBeforeDuration { get; set; }
+
+        /// <summary>
+        /// If set, O (Organization) will be set to this value in certificates issued by this role.
+        /// </summary>
+        /// <value>If set, O (Organization) will be set to this value in certificates issued by this role.</value>
+        [JsonPropertyName("organization")]
+        public List<string> Organization { get; set; }
+
+        /// <summary>
+        /// If set, OU (OrganizationalUnit) will be set to this value in certificates issued by this role.
+        /// </summary>
+        /// <value>If set, OU (OrganizationalUnit) will be set to this value in certificates issued by this role.</value>
+        [JsonPropertyName("ou")]
+        public List<string> Ou { get; set; }
+
+        /// <summary>
+        /// A comma-separated string or list of policy OIDs, or a JSON list of qualified policy information, which must include an oid, and may include a notice and/or cps url, using the form [{\&quot;oid\&quot;&#x3D;\&quot;1.3.6.1.4.1.7.8\&quot;,\&quot;notice\&quot;&#x3D;\&quot;I am a user Notice\&quot;}, {\&quot;oid\&quot;&#x3D;\&quot;1.3.6.1.4.1.44947.1.2.4 \&quot;,\&quot;cps\&quot;&#x3D;\&quot;https://example.com\&quot;}].
+        /// </summary>
+        /// <value>A comma-separated string or list of policy OIDs, or a JSON list of qualified policy information, which must include an oid, and may include a notice and/or cps url, using the form [{\&quot;oid\&quot;&#x3D;\&quot;1.3.6.1.4.1.7.8\&quot;,\&quot;notice\&quot;&#x3D;\&quot;I am a user Notice\&quot;}, {\&quot;oid\&quot;&#x3D;\&quot;1.3.6.1.4.1.44947.1.2.4 \&quot;,\&quot;cps\&quot;&#x3D;\&quot;https://example.com\&quot;}].</value>
+        [JsonPropertyName("policy_identifiers")]
+        public List<string> PolicyIdentifiers { get; set; }
+
+        /// <summary>
+        /// If set, Postal Code will be set to this value in certificates issued by this role.
+        /// </summary>
+        /// <value>If set, Postal Code will be set to this value in certificates issued by this role.</value>
+        [JsonPropertyName("postal_code")]
+        public List<string> PostalCode { get; set; }
+
+        /// <summary>
+        /// If set, Province will be set to this value in certificates issued by this role.
+        /// </summary>
+        /// <value>If set, Province will be set to this value in certificates issued by this role.</value>
+        [JsonPropertyName("province")]
+        public List<string> Province { get; set; }
+
+        /// <summary>
+        /// If set to false, makes the &#39;common_name&#39; field optional while generating a certificate.
+        /// </summary>
+        /// <value>If set to false, makes the &#39;common_name&#39; field optional while generating a certificate.</value>
+        [JsonPropertyName("require_cn")]
+        public bool RequireCn { get; set; }
+
+        /// <summary>
+        /// If set, certificates are flagged for server auth use. Defaults to true. See also RFC 5280 Section 4.2.1.12.
+        /// </summary>
+        /// <value>If set, certificates are flagged for server auth use. Defaults to true. See also RFC 5280 Section 4.2.1.12.</value>
+        [JsonPropertyName("server_flag")]
+        public bool ServerFlag { get; set; }
+
+        /// <summary>
+        /// The number of bits to use in the signature algorithm; accepts 256 for SHA-2-256, 384 for SHA-2-384, and 512 for SHA-2-512. Defaults to 0 to automatically detect based on key length (SHA-2-256 for RSA keys, and matching the curve size for NIST P-Curves).
+        /// </summary>
+        /// <value>The number of bits to use in the signature algorithm; accepts 256 for SHA-2-256, 384 for SHA-2-384, and 512 for SHA-2-512. Defaults to 0 to automatically detect based on key length (SHA-2-256 for RSA keys, and matching the curve size for NIST P-Curves).</value>
+        [JsonPropertyName("signature_bits")]
+        public int SignatureBits { get; set; }
+
+        /// <summary>
+        /// If set, Street Address will be set to this value in certificates issued by this role.
+        /// </summary>
+        /// <value>If set, Street Address will be set to this value in certificates issued by this role.</value>
+        [JsonPropertyName("street_address")]
+        public List<string> StreetAddress { get; set; }
+
+        /// <summary>
+        /// The lease duration (validity period of the certificate) if no specific lease duration is requested. The lease duration controls the expiration of certificates issued by this backend. Defaults to the system default value or the value of max_ttl, whichever is shorter.
+        /// </summary>
+        /// <value>The lease duration (validity period of the certificate) if no specific lease duration is requested. The lease duration controls the expiration of certificates issued by this backend. Defaults to the system default value or the value of max_ttl, whichever is shorter.</value>
+        [JsonPropertyName("ttl")]
+        public long Ttl { get; set; }
+
+        /// <summary>
+        /// If set, when used with a signing profile, the common name in the CSR will be used. This does *not* include any requested Subject Alternative Names; use use_csr_sans for that. Defaults to true.
+        /// </summary>
+        /// <value>If set, when used with a signing profile, the common name in the CSR will be used. This does *not* include any requested Subject Alternative Names; use use_csr_sans for that. Defaults to true.</value>
+        [JsonPropertyName("use_csr_common_name")]
+        public bool UseCsrCommonName { get; set; }
+
+        /// <summary>
+        /// If set, when used with a signing profile, the SANs in the CSR will be used. This does *not* include the Common Name (cn); use use_csr_common_name for that. Defaults to true.
+        /// </summary>
+        /// <value>If set, when used with a signing profile, the SANs in the CSR will be used. This does *not* include the Common Name (cn); use use_csr_common_name for that. Defaults to true.</value>
+        [JsonPropertyName("use_csr_sans")]
+        public bool UseCsrSans { get; set; }
+
+        /// <summary>
+        /// Whether or not to use PSS signatures when using a RSA key-type issuer. Defaults to false.
+        /// </summary>
+        /// <value>Whether or not to use PSS signatures when using a RSA key-type issuer. Defaults to false.</value>
+        [JsonPropertyName("use_pss")]
+        public bool UsePss { get; set; }
+    }
+}

--- a/src/VaultSharp/V1/SecretsEngines/PKI/Roles/RolesData.cs
+++ b/src/VaultSharp/V1/SecretsEngines/PKI/Roles/RolesData.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace VaultSharp.V1.SecretsEngines.PKI.Roles
+{
+    public class RolesData
+    {
+        [JsonPropertyName("keys")]
+        public List<string> Keys { get; set; }
+    }
+}

--- a/src/VaultSharp/VaultSharp.csproj
+++ b/src/VaultSharp/VaultSharp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net47;net471;net472;net48;net481;netstandard2.0;netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net462;net47;net471;net472;net48;net481;netstandard2.0;netstandard2.1;net6.0;net8.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>VaultSharp.snk</AssemblyOriginatorKeyFile>
@@ -193,6 +193,10 @@ This library is built with .NET Standard 2.0, .NET Standard 2.1, 4.6.2, 4.7.2*, 
   <PropertyGroup Condition="'$(TargetFramework)'=='net8.0'">
     <AssemblyTitle>VaultSharp .NET 8</AssemblyTitle>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Folder Include="V1\SecretsEngines\PKI\Certificates\" />
+  </ItemGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net6.0|AnyCPU'">
     <WarningLevel>5</WarningLevel>


### PR DESCRIPTION
Extends the PKI secrets engine support with full CRUD management for issuers, keys, and roles, and drops net7.0 from the target frameworks.

- Added IPKIIssuers interface and PKISecretIssuersProvider with operations to list, read, update, and delete PKI issuers, including issuer config management
- Added IPKIKeys interface and PKISecretKeysProvider with operations to list, read, import, generate, and delete PKI keys
- Added IPKIRoles interface and PKISecretRolesProvider with operations to list, read, create, update, and delete PKI roles
- Added supporting data models: IssuerData, IssuerConfigRequestData, IssuerConfigResponseData, KeyData, RoleData, and related enums (IssuerFormat, IssuerPrivetKeyFormat, KeyGenerationType, PrivateKeyType, KeyUsageConstants, ExtendedKeyUsageConstants)
- Exposed Issuers, Keys, and Roles as top-level properties on IPKISecretsEngine
- Removed net7.0 from the list of target frameworks in VaultSharp.csproj